### PR TITLE
Add CurrentTenant class that can be resolved from container

### DIFF
--- a/docs/basic-usage/automatically-determining-the-current-tenant.md
+++ b/docs/basic-usage/automatically-determining-the-current-tenant.md
@@ -19,10 +19,11 @@ In the `multitenancy` config file, you specificy the tenant finder in the `tenan
 'tenant_finder' => Spatie\Multitenancy\TenantFinder\DomainTenantFinder::class,
 ```
 
-If there is a tenant returned by the tenant finder, [all configured tasks](https://docs.spatie.be/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) will be performed on it. After that the tenant instance will be bound in the container using the `currentTenant` key.
+If there is a tenant returned by the tenant finder, [all configured tasks](https://docs.spatie.be/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) will be performed on it. After that the tenant instance will be bound in the container using the `currentTenant` key and `\Spatie\Multitenancy\Models\Contracts\CurrentTenant` class.
 
 ```php
-app('currentTenant') // will return the current tenant or `null`
+app('currentTenant'); // will return the current tenant or `null`
+app(\Spatie\Multitenancy\Models\Contracts\CurrentTenant::class); // will return the current tenant or `null`
 ```
 
 You can create a tenant finder of your own. A valid tenant finder is any class that extends `Spatie\Multitenancy\TenantFinder\TenantFinder`. You must implement this abstract method:

--- a/docs/basic-usage/working-with-the-current-tenant.md
+++ b/docs/basic-usage/working-with-the-current-tenant.md
@@ -13,10 +13,18 @@ You can find the current method like this.
 Spatie\Multitenancy\Models\Tenant::current(); // returns the current tenant, or if not tenant is current, `null`
 ```
 
-A current tenant will also be bound in the container using the `currentTenant` key.
+A current tenant will also be bound in the container using the `currentTenant` key and `Spatie\Multitenancy\Models\Contracts\CurrentTenant` class.
 
 ```php
 app('currentTenant'); // returns the current tenant, or if not tenant is current, `null`
+```
+
+```php
+use Spatie\Multitenancy\Models\Contracts\CurrentTenant;
+
+Route::get('/current-tenant', function (CurrentTenant $currentTenant) {
+    return $currentTenant; // returns the current Tenant model
+});
 ```
 
 ### Checking if there is a current tenant

--- a/src/Actions/MakeTenantCurrentAction.php
+++ b/src/Actions/MakeTenantCurrentAction.php
@@ -4,6 +4,7 @@ namespace Spatie\Multitenancy\Actions;
 
 use Spatie\Multitenancy\Events\MadeTenantCurrentEvent;
 use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
+use Spatie\Multitenancy\Models\Contracts\CurrentTenant;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 use Spatie\Multitenancy\Tasks\TasksCollection;
@@ -41,9 +42,9 @@ class MakeTenantCurrentAction
     {
         $containerKey = config('multitenancy.current_tenant_container_key');
 
-        app()->forgetInstance($containerKey);
-
         app()->instance($containerKey, $tenant);
+
+        app()->instance(CurrentTenant::class, $tenant);
 
         return $this;
     }

--- a/src/Models/Contracts/CurrentTenant.php
+++ b/src/Models/Contracts/CurrentTenant.php
@@ -6,5 +6,4 @@ use Spatie\Multitenancy\Models\Tenant;
 
 class CurrentTenant extends Tenant
 {
-
 }

--- a/src/Models/Contracts/CurrentTenant.php
+++ b/src/Models/Contracts/CurrentTenant.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Multitenancy\Models\Contracts;
+
+use Spatie\Multitenancy\Models\Tenant;
+
+class CurrentTenant extends Tenant
+{
+
+}

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Spatie\Multitenancy\Actions\ForgetCurrentTenantAction;
 use Spatie\Multitenancy\Actions\MakeTenantCurrentAction;
 use Spatie\Multitenancy\Models\Concerns\UsesLandlordConnection;
+use Spatie\Multitenancy\Models\Contracts\CurrentTenant;
 use Spatie\Multitenancy\TenantCollection;
 
 class Tenant extends Model

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Spatie\Multitenancy\Actions\ForgetCurrentTenantAction;
 use Spatie\Multitenancy\Actions\MakeTenantCurrentAction;
 use Spatie\Multitenancy\Models\Concerns\UsesLandlordConnection;
-use Spatie\Multitenancy\Models\Contracts\CurrentTenant;
 use Spatie\Multitenancy\TenantCollection;
 
 class Tenant extends Model

--- a/tests/Feature/Models/TenantTest.php
+++ b/tests/Feature/Models/TenantTest.php
@@ -7,6 +7,7 @@ use Spatie\Multitenancy\Events\ForgettingCurrentTenantEvent;
 use Spatie\Multitenancy\Events\ForgotCurrentTenantEvent;
 use Spatie\Multitenancy\Events\MadeTenantCurrentEvent;
 use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
+use Spatie\Multitenancy\Models\Contracts\CurrentTenant;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tests\TestCase;
 
@@ -32,7 +33,7 @@ class TenantTest extends TestCase
     }
 
     /** @test */
-    public function it_will_bind_the_current_tenant_in_the_container()
+    public function it_will_bind_the_current_tenant_in_the_container_by_config_key()
     {
         $containerKey = config('multitenancy.current_tenant_container_key');
 
@@ -44,6 +45,19 @@ class TenantTest extends TestCase
 
         $this->assertInstanceOf(Tenant::class, app($containerKey));
         $this->assertEquals($this->tenant->id, app($containerKey)->id);
+    }
+
+    /** @test */
+    public function it_will_bind_the_current_tenant_in_the_container_by_contract_class()
+    {
+        $this->assertFalse(app()->has(CurrentTenant::class));
+
+        $this->tenant->makeCurrent();
+
+        $this->assertTrue(app()->has(CurrentTenant::class));
+
+        $this->assertInstanceOf(Tenant::class, app(CurrentTenant::class));
+        $this->assertEquals($this->tenant->id, app(CurrentTenant::class)->id);
     }
 
     /** @test */


### PR DESCRIPTION
Allows for things like this:

```php
use Spatie\Multitenancy\Models\Contracts\CurrentTenant;

Route::get('/current-tenant', function (CurrentTenant $currentTenant) {
    return $currentTenant; // returns the current Tenant model
});
```