### PR TITLE
Check a job payload has a tenantId index

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -39,7 +39,7 @@ class MakeQueueTenantAwareAction
     protected function listenForJobsBeingProcessed(): self
     {
         app('events')->listen(JobProcessing::class, function (JobProcessing $event) {
-            $tenantId = $event->job->payload()['tenantId'];
+            $tenantId = $event->job->payload()['tenantId'] ?? null;
 
             if (! $tenantId) {
                 return;


### PR DESCRIPTION
In case jobs were in queue that don't have the tenantId index, it'll currently error. This check will prevent that.