### PR TITLE
Allow multiple Tenant Domains

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -4,6 +4,7 @@ use Spatie\Multitenancy\Actions\ForgetCurrentTenantAction;
 use Spatie\Multitenancy\Actions\MakeQueueTenantAwareAction;
 use Spatie\Multitenancy\Actions\MakeTenantCurrentAction;
 use Spatie\Multitenancy\Actions\MigrateTenantAction;
+use Spatie\Multitenancy\Models\Domain;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tasks\PrefixCacheTask;
 
@@ -32,6 +33,13 @@ return [
      * It must be or extend `Spatie\Multitenancy\Models\Tenant::class`
      */
     'tenant_model' => Tenant::class,
+
+    /*
+     * This class is the model used for storing configuration on the domains in use by tenants.
+     *
+     * It must be or extend `Spatie\Multitenancy\Models\Domain::class`
+     */
+    'domain_model' => Domain::class,
 
     /*
      * If there is a current tenant when dispatching a job, the id of the current tenant

--- a/database/migrations/landlord/create_landlord_domains_table.php.stub
+++ b/database/migrations/landlord/create_landlord_domains_table.php.stub
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLandlordDomainsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('domains', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('set null');
+
+            $table->string('domain')->unique();
+            $table->timestamps();
+        });
+    }
+}

--- a/database/migrations/landlord/create_landlord_tenants_table.php.stub
+++ b/database/migrations/landlord/create_landlord_tenants_table.php.stub
@@ -11,7 +11,6 @@ class CreateLandlordTenantsTable extends Migration
         Schema::create('tenants', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('domain')->unique();
             $table->string('database')->unique();
             $table->timestamps();
         });

--- a/src/Models/Domain.php
+++ b/src/Models/Domain.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Multitenancy\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Multitenancy\Models\Concerns\UsesLandlordConnection;
+
+class Domain extends Model
+{
+    use UsesLandlordConnection;
+
+    protected $fillable = ['domain'];
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(config('multitenancy.tenant_model'));
+    }
+}

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -73,4 +73,10 @@ class Tenant extends Model
     {
         return $this->database;
     }
+
+    public function domains() {
+        $domainModelClass = config('multitenancy.domain_model');
+
+        return $this->hasMany($domainModelClass);
+    }
 }

--- a/src/TenantFinder/DomainTenantFinder.php
+++ b/src/TenantFinder/DomainTenantFinder.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Multitenancy\TenantFinder;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
 use Spatie\Multitenancy\Models\Tenant;
@@ -14,6 +15,8 @@ class DomainTenantFinder extends TenantFinder
     {
         $host = $request->getHost();
 
-        return $this->getTenantModel()::whereDomain($host)->first();
+        return $this->getTenantModel()::whereHas('domains', function (Builder $query) use ($host){
+            $query->where('domain', '=', $host);
+        })->first();
     }
 }

--- a/tests/Feature/TenantFinder/DomainTenantFinderTest.php
+++ b/tests/Feature/TenantFinder/DomainTenantFinderTest.php
@@ -21,9 +21,26 @@ class DomainTenantFinderTest extends TestCase
     /** @test */
     public function it_can_find_a_tenant_for_the_current_domain()
     {
-        $tenant = factory(Tenant::class)->create(['domain' => 'my-domain.com']);
+        $tenant = factory(Tenant::class)->create();
+        $tenant->domains()->create(['domain' => 'my-domain.com']);
 
         $request = Request::create('https://my-domain.com');
+
+        $this->assertEquals($tenant->id, $this->tenantFinder->findForRequest($request)->id);
+    }
+
+    /** @test */
+    public function it_can_find_a_tenant_that_has_multiple_domains_using_a_single_domain()
+    {
+        $tenant = factory(Tenant::class)->create();
+        $tenant->domains()->create(['domain' => 'my-domain.com']);
+        $tenant->domains()->create(['domain' => 'my-domain.net']);
+
+        $request = Request::create('https://my-domain.com');
+
+        $this->assertEquals($tenant->id, $this->tenantFinder->findForRequest($request)->id);
+
+        $request = Request::create('https://my-domain.net');
 
         $this->assertEquals($tenant->id, $this->tenantFinder->findForRequest($request)->id);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,6 +35,7 @@ abstract class TestCase extends Orchestra
     protected function migrateDb(): self
     {
         $landLordMigrationsPath = realpath(__DIR__ . '/database/migrations/landlord');
+        $landLordMigrationsPath = str_replace('\\', '/', $landLordMigrationsPath);
 
         $this
             ->artisan("migrate --database=landlord --path={$landLordMigrationsPath} --realpath")

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,16 +62,18 @@ abstract class TestCase extends Orchestra
         config([
             'database.connections.landlord' => [
                 'driver' => 'mysql',
-                'username' => 'root',
-                'host' => '127.0.1',
+                'username' => env('DB_USERNAME', 'root'),
+                'host' => env('DB_HOST', '127.0.0.1'),
+                'port' => env('DB_PORT', '3306'),
                 'password' => env('DB_PASSWORD'),
                 'database' => 'laravel_mt_landlord',
             ],
 
             'database.connections.tenant' => [
                 'driver' => 'mysql',
-                'username' => 'root',
-                'host' => '127.0.1',
+                'username' => env('DB_USERNAME', 'root'),
+                'host' => env('DB_HOST', '127.0.0.1'),
+                'port' => env('DB_PORT', '3306'),
                 'password' => env('DB_PASSWORD'),
                 'database' => null,
             ],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace Spatie\Multitenancy\Tests;
 use Illuminate\Support\Facades\DB;
 use Orchestra\Testbench\Concerns\WithLaravelMigrations;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Spatie\Multitenancy\Models\Domain;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\MultitenancyServiceProvider;
 
@@ -20,7 +21,11 @@ abstract class TestCase extends Orchestra
 
         $this->migrateDb();
 
+        // The below should be a suitable workaround as the current test settings are fixed to MySQL.
+        DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+        Domain::truncate();
         Tenant::truncate();
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
 
         DB::table('jobs')->truncate();
     }

--- a/tests/database/factories/DomainFactory.php
+++ b/tests/database/factories/DomainFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use Faker\Generator;
+use Spatie\Multitenancy\Models\Domain;
+
+$factory->define(Domain::class, fn (Generator $faker) => [
+    'domain' => $faker->unique()->domainName,
+]);

--- a/tests/database/factories/TenantFactory.php
+++ b/tests/database/factories/TenantFactory.php
@@ -7,6 +7,5 @@ use Spatie\Multitenancy\Models\Tenant;
 
 $factory->define(Tenant::class, fn (Generator $faker) => [
     'name' => $faker->name,
-    'domain' => $faker->unique()->domainName,
     'database' => $faker->userName,
 ]);

--- a/tests/database/migrations/landlord/2014_10_12_000000_create_landlord_tenants_table.php
+++ b/tests/database/migrations/landlord/2014_10_12_000000_create_landlord_tenants_table.php
@@ -11,7 +11,6 @@ class CreateLandLordTenantsTable extends Migration
         Schema::create('tenants', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('domain')->unique();
             $table->string('database')->unique();
             $table->timestamps();
         });

--- a/tests/database/migrations/landlord/2014_10_12_000001_create_landlord_domains_table.php
+++ b/tests/database/migrations/landlord/2014_10_12_000001_create_landlord_domains_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLandlordDomainsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('domains', function (Blueprint $table) {
+            $table->id();
+
+            $table->bigInteger('tenant_id')->unsigned()->nullable();
+            $table->foreign('tenant_id')->references('id')->on('tenants')->onDelete('set null');
+
+            $table->string('domain')->unique();
+            $table->timestamps();
+        });
+    }
+}


### PR DESCRIPTION
First of all, appreciate the work on this and how quickly you've turned it from an idea into a solution!

I am building a solution for a client which does not require a tenant to have a domain, instead a user is able to select the current tenant by dropdown. This value is then stored in the session data and we set the correct tenant using a custom tenant finder. My only concern here is that currently a tenant 'requires' a domain name as the current table structure of the 'tenants' table forces a non-null unique value for the domains field. This is not a deal-breaker as we could create a random string and fill in the field for tenants which don't have a domain, and then find a way to filter it out from the backend interface when it's not a real domain.

In addition to this, there's also the requirement of a tenant having multiple domains. Whether this consists of the www and non-www variants of their domain, or additional domains that the client may hold and would like assigning to the same tenant.

With that being said, this PR should handle both situations. The PR is not complete in terms of tests or actual real-world testing, however, it provides the basis for a proof of concept and all tests pass. Only 1 existing test had to be modified slightly due to the domain being passed through to the Tenant to be created.

Would welcome any thoughts on this and what additional tests & logic may be required to get such a PR merged if at all possible.

Appreciate your time if you've made it this far 😄 

(PS, there's two additional commits to get the test suite working on Windows and to extract some additional MySQL details into the PHPUnit Environment Variables.)