### PR TITLE
tenantId key does not always exist.

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -39,7 +39,7 @@ class MakeQueueTenantAwareAction
     protected function listenForJobsBeingProcessed(): self
     {
         app('events')->listen(JobProcessing::class, function (JobProcessing $event) {
-            $tenantId = $event->job->payload()['tenantId'];
+            $tenantId = $event->job->payload()['tenantId'] ?? null;
 
             if (! $tenantId) {
                 return;


### PR DESCRIPTION
I believe I'm correct in my thinking here, this error started cropping up which at first I thought was an issue with my app but after further testing, I believe it relates to the lines mentioned in this PR.

This key-value pair is not always set within the payload. This occurs if either the tenant is not set when dispatching the job (line 31-33), or the job is a Tenant Unaware job (line 27-39).

However, this PR breaks the following tests -

`Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\QueueIsTenantAwareByDefaultTest::it_will_not_break_when_no_tenant_is_set`

`Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\QueueIsTenantAwareByDefaultTest::it_will_not_make_jobs_tenant_aware_if_the_config_setting_is_set_to_false`

`Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\QueueIsTenantAwareByDefaultTest::it_will_not_make_a_job_tenant_aware_if_it_implement_NotTenantAware`


With regards to the `it_will_not_break_when_no_tenant_is_set` test, I believe what is happening here is you're actually triggering the same error I am during your testing, but instead of it being outputted it's causing the Job to fail and therefore returning a null response to the test, which is what it's expecting.

If I add `$this->doesntExpectEvents(JobFailed::class);` to the top of that test, it then starts to fail. As the job is actually failing and triggering a JobFailed event.

Admittedly I've not looked into the other two tests as I want to be sure I've understood the logic and how the test I have looked into should work first.