### PR TITLE
Use the configured tenant model in artisan command

### DIFF
--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -5,15 +5,18 @@ namespace Spatie\Multitenancy\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
+use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
 use Spatie\Multitenancy\Models\Tenant;
 
 class TenantsArtisanCommand extends Command
 {
+    use UsesTenantModel;
+
     protected $signature = 'tenants:artisan {artisanCommand} {--tenant=*}';
 
     public function handle()
     {
-        $tenantQuery = Tenant::query();
+        $tenantQuery = $this->getTenantModel()->newQuery();
 
         if (! $artisanCommand = $this->argument('artisanCommand')) {
             $artisanCommand = $this->ask('Which artisan command do you want to run for all tenants?');


### PR DESCRIPTION
I have some custom methods on my tenant model which get called by a `SwitchTenantTask`. When running the `tenants:artisan` command, those methods didn't exist because it used `Spatie\Multitenancy\Models\Tenant` instead of  `App\Tenant` which I configured under `multitenancy.tenant_model`.