### PR TITLE
No need to determine `$tenantId` twice...

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -49,7 +49,7 @@ class MakeQueueTenantAwareAction
                 return;
             }
             /** @var \Spatie\Multitenancy\Models\Tenant $tenant */
-            if (! $tenant = $this->getTenantModel()::find($event->job->payload()['tenantId'])) {
+            if (! $tenant = $this->getTenantModel()::find($tenantId)) {
                 return;
             }
 


### PR DESCRIPTION
Minor change to DRY up the code a bit.  Hope I didn't miss anything.  😛

Also thought about moving the config check up above tenant ID check, but thought that micro-optimization might be a bit much.  😆 