### PR TITLE
Remove unused import from config

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -5,7 +5,6 @@ use Spatie\Multitenancy\Actions\MakeQueueTenantAwareAction;
 use Spatie\Multitenancy\Actions\MakeTenantCurrentAction;
 use Spatie\Multitenancy\Actions\MigrateTenantAction;
 use Spatie\Multitenancy\Models\Tenant;
-use Spatie\Multitenancy\Tasks\PrefixCacheTask;
 
 return [
     /*


### PR DESCRIPTION
Removes an unused import from the config.

(Or should it be registered under `'switch_tenant_tasks'`?)