### PR TITLE
Add down method to migration stub

### DIFF
--- a/database/migrations/landlord/create_landlord_tenants_table.php.stub
+++ b/database/migrations/landlord/create_landlord_tenants_table.php.stub
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Schema;
 
 class CreateLandlordTenantsTable extends Migration
 {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
     public function up()
     {
         Schema::create('tenants', function (Blueprint $table) {
@@ -15,5 +20,15 @@ class CreateLandlordTenantsTable extends Migration
             $table->string('database')->unique();
             $table->timestamps();
         });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tenants');
     }
 }


### PR DESCRIPTION
Make sure to drop the tenants table when resetting or refreshing the migrations.