### PR TITLE
Update links in the docs

### DIFF
--- a/docs/installation/using-multiple-databases.md
+++ b/docs/installation/using-multiple-databases.md
@@ -78,7 +78,7 @@ The package also provides [other tasks](/laravel-multitenancy/v1/using-tasks-to-
 
 ### Creating tenant databases
 
-Now that automatic database switching for tenants is configured, you can migrate the tenant databases. Because there are so many ways to go about it, the package does not handle creating databases. You should take care of creating new tenant databases in your own application code. A nice place to trigger this could be [when a `Tenant` model gets created](/laravel-multitenancy/v1/basic-usage/using-a-custom-tenant-model/#performing-actions-when-a-tenant-gets-created).
+Now that automatic database switching for tenants is configured, you can migrate the tenant databases. Because there are so many ways to go about it, the package does not handle creating databases. You should take care of creating new tenant databases in your own application code. A nice place to trigger this could be [when a `Tenant` model gets created](/laravel-multitenancy/v1/advanced-usage/using-a-custom-tenant-model/#performing-actions-when-a-tenant-gets-created).
 
 If you want to get a feel of how the package works, you could create a couple of rows in the `tenants` table, fill the `database` attribute and manually create those databases.
 
@@ -133,4 +133,4 @@ All models in your project should either use the `UsesLandLordConnection` or `Us
 
 ### Next steps
 
-When using multiple tenants, you probably want to [isolate the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/cache/) or [use separate filesystems per tenant](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/filesystem/), ... These things are perform by task classes that will be executed when making a tenant the current one.
+When using multiple tenants, you probably want to [isolate the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache/) or [use separate filesystems per tenant](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/filesystem/), ... These things are perform by task classes that will be executed when making a tenant the current one.

--- a/docs/using-tasks-to-prepare-the-environment/overview.md
+++ b/docs/using-tasks-to-prepare-the-environment/overview.md
@@ -11,7 +11,7 @@ You can easily [create your own tasks](/laravel-multitenancy/v1/using-tasks-to-p
 
 The package ships with these tasks:
 
-- [switch the tenant database](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/database) (required when using multiple tenant databases)
-- [prefixing the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/cache)
+- [switch the tenant database](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/switching-databases) (required when using multiple tenant databases)
+- [prefixing the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache)
 
 These tasks are optional. When you need one, just add it to the `switch_tenant_tasks` key of the `multitenancy` config file.


### PR DESCRIPTION
Still one missing link:
[use separate filesystems per tenant](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/filesystem/)
in installation/using-multiple-databases
But it seems a page for this task is missing (or the task does not exist at all)