### PR TITLE
Error trying to query the 'tenants' table on a tenant connection 

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -49,7 +49,7 @@ class MakeQueueTenantAwareAction
                 return;
             }
             /** @var \Spatie\Multitenancy\Models\Tenant $tenant */
-            if (! $tenant = $this->getTenantModel()::find($tenantId)) {
+            if (! $tenant = $this->getTenantModel()::current() ?? $this->getTenantModel()::find($tenantId)) {
                 return;
             }
 


### PR DESCRIPTION
Tested using laravel 7 and Laravel-Nova 3.6:

I have a nova-action that calls a laravel-job to perform some updates in the database. 

When the action is executed, an error is thrown on the `class MakeQueueTenantAwareAction::class` when it tries to find the current tenant by id:

```
            /** @var \Spatie\Multitenancy\Models\Tenant $tenant */
            if (! $tenant = $this->getTenantModel()::find($tenantId)) {
                return;
            }
```

This happens because the `"database.connections.{$tenantConnectionName}.database"` is changed from the `SwitchTenantDatabaseTask::setTenantConnectionDatabaseName()` method, so once the current-tenant is already "resolved" the "landlord" connection database changes to whatever the current-tenant database is, so when it tries to find the current tenant with `Tenant::find(1)` it fails because the `tenants` table  only exists on the landlord database.

```
[previous exception] [object] (PDOException(code: 42S02): SQLSTATE[42S02]: Base table or view not found: 1146 Table 'tenant-1.tenants' doesn't exist at /home/vagrant/Code/video-dashboard/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:64)
```

Checking if `Tenant::current()` exists before trying to find the tenant by id with `Tenant::find($id)` solves this issue.

