### PR TITLE
tenants:artisan search tenant by ids or domains

### DIFF
--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -22,8 +22,9 @@ class TenantsArtisanCommand extends Command
             $artisanCommand = $this->ask('Which artisan command do you want to run for all tenants?');
         }
 
-        if ($tenantIds = $this->option('tenant')) {
-            $tenantQuery->whereIn('id', Arr::wrap($tenantIds));
+        if ($tenants = $this->option('tenant')) {
+            $tenantQuery->whereIn('id', Arr::wrap($tenants))
+                ->orWhereIn('domain', Arr::wrap($tenants));
         }
 
         $tenantQuery

--- a/tests/Feature/Commands/TenantsArtisanCommandTest.php
+++ b/tests/Feature/Commands/TenantsArtisanCommandTest.php
@@ -45,9 +45,19 @@ class TenantsArtisanCommandTest extends TestCase
     }
 
     /** @test */
-    public function it_can_migrate_a_specific_tenant()
+    public function it_can_migrate_a_specific_tenant_by_id()
     {
         $this->artisan('tenants:artisan migrate --tenant=' . $this->anotherTenant->id . '"')->assertExitCode(0);
+
+        $this
+            ->assertTenantDatabaseDoesNotHaveTable($this->tenant, 'migrations')
+            ->assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');
+    }
+
+    /** @test */
+    public function it_can_migrate_a_specific_tenant_by_domain()
+    {
+        $this->artisan('tenants:artisan migrate --tenant=' . $this->anotherTenant->domain . '"')->assertExitCode(0);
 
         $this
             ->assertTenantDatabaseDoesNotHaveTable($this->tenant, 'migrations')


### PR DESCRIPTION
Ids are great, but isn't more simple to use tenants:run also by domains?

Search by ID:
`php artisan tenants:artisan route:list --tenant=1`

Search by Domain:
`php artisan tenants:artisan route:list --tenant=tenant1.spatie.be`

Mixed search:
`php artisan tenants:artisan route:list --tenant=2,tenant1.spatie.be`