### PR TITLE
Unset the previous tenant if a queue job cannot load its own tenant

### DIFF
--- a/docs/basic-usage/making-queues-tenant-aware.md
+++ b/docs/basic-usage/making-queues-tenant-aware.md
@@ -40,3 +40,9 @@ class TestJob implements ShouldQueue, NotTenantAware
     }
 }
 ```
+
+## When the tenant cannot be retrieved
+
+If a tenant aware job is unable to retrieve the tenant, for example because the tenant was deleted before the job was processed, the job will fail with an instance of `Spatie\Multitenancy\Exceptions\NoCurrentTenant`.
+
+On the other hand, a job that is not tenant aware will make no modifications to the current tenant, which may still be set from a previous job. As such, it is important that your jobs make no assumptions about the active tenant unless they are tenant aware.

--- a/tests/Feature/TenantAwareJobs/JobIsDeletedWhenTenantCannotBeRetrievedTest.php
+++ b/tests/Feature/TenantAwareJobs/JobIsDeletedWhenTenantCannotBeRetrievedTest.php
@@ -1,0 +1,110 @@
+<?php
+
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs;
+
+use Illuminate\Contracts\Bus\Dispatcher;
+use Spatie\Multitenancy\Exceptions\NoCurrentTenant;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\NotTenantAwareTestJob;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TenantAwareTestJob;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TestJob;
+use Spatie\Multitenancy\Tests\TestCase;
+use Spatie\Valuestore\Valuestore;
+
+class JobIsDeletedWhenTenantCannotBeRetrievedTest extends TestCase
+{
+    private Tenant $tenant;
+
+    private Valuestore $valuestore;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+        config()->set('queue.default', 'sync');
+
+        $this->tenant = factory(Tenant::class)->create();
+
+        $this->valuestore = Valuestore::make($this->tempFile('tenantAware.json'))->flush();
+    }
+
+    /** @test */
+    public function it_will_fail_a_job_when_no_tenant_is_present_and_queues_are_tenant_aware_by_default()
+    {
+        config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+
+        $job = new TestJob($this->valuestore);
+
+        try {
+            app(Dispatcher::class)->dispatch($job);
+        } catch (NoCurrentTenant $e) {
+            // Assert the job did not run
+            $this->assertFalse($this->valuestore->has('tenantId'));
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /** @test */
+    public function it_will_fail_a_job_when_no_tenant_is_present_and_job_implements_the_TenantAware_interface()
+    {
+        config()->set('multitenancy.queues_are_tenant_aware_by_default', false);
+
+        $job = new TenantAwareTestJob($this->valuestore);
+
+        try {
+            app(Dispatcher::class)->dispatch($job);
+        } catch (NoCurrentTenant $e) {
+            $this->assertFalse($this->valuestore->has('tenantId'));
+
+            return;
+        }
+
+        $this->fail();
+    }
+
+    /** @test */
+    public function it_will_not_fail_a_job_when_no_tenant_is_present_and_queues_are_not_tenant_aware_by_default()
+    {
+        config()->set('multitenancy.queues_are_tenant_aware_by_default', false);
+
+        $job = new TestJob($this->valuestore);
+
+        app(Dispatcher::class)->dispatch($job);
+
+        $this->assertTrue($this->valuestore->has('tenantId'));
+        $this->assertNull($this->valuestore->get('tenantId'));
+    }
+
+    /** @test */
+    public function it_will_not_fail_a_job_when_no_tenant_is_present_and_job_implements_the_NotTenantAware_interface()
+    {
+        config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+
+        $job = new NotTenantAwareTestJob($this->valuestore);
+
+        app(Dispatcher::class)->dispatch($job);
+
+        $this->assertTrue($this->valuestore->has('tenantId'));
+        $this->assertNull($this->valuestore->get('tenantId'));
+    }
+
+    /** @test */
+    public function it_will_not_touch_the_tenant_if_the_job_is_not_tenant_aware()
+    {
+        $this->tenant->makeCurrent();
+        $job = new NotTenantAwareTestJob($this->valuestore);
+
+        // Simulate a tenant being set from a previous queue job
+        $this->assertTrue(Tenant::checkCurrent());
+
+        app(Dispatcher::class)->dispatch($job);
+
+        // Assert that the active tenant was not modified
+        $this->assertSame($this->tenant->id, Tenant::current()->id);
+    }
+}

--- a/tests/Feature/TenantAwareJobs/QueueIsTenantAwareByDefaultTest.php
+++ b/tests/Feature/TenantAwareJobs/QueueIsTenantAwareByDefaultTest.php
@@ -47,18 +47,6 @@ class QueueIsTenantAwareByDefaultTest extends TestCase
     }
 
     /** @test */
-    public function it_will_not_break_when_no_tenant_is_set()
-    {
-        $job = new TestJob($this->valuestore);
-        app(Dispatcher::class)->dispatch($job);
-
-        $this->artisan('queue:work --once')->assertExitCode(0);
-
-        $currentTenantIdInJob = $this->valuestore->get('tenantId');
-        $this->assertNull($currentTenantIdInJob);
-    }
-
-    /** @test */
     public function it_will_inject_the_right_tenant_even_when_the_current_tenant_switches()
     {
         /** @var \Spatie\Multitenancy\Models\Tenant $anotherTenant */


### PR DESCRIPTION
This is a fix for behaviour that I believe could lead to unintended data disclosure if you have a mixture of tenant and non-tenant routes in your app, or if a tenant is deleted before its queue job runs. 

The problem lies in the fact that each queue worker only boots the app once—any global state changes made by a queue job will still be present for the next queue job. 

If a tenant aware job cannot fetch its tenant (either because it no longer exists or because it was not set when dispatched), that job will continue to run under whatever tenant the last job used.

As the simplest example, imagine the following routes and job, running on a Redis queue.

```php
Route::get('tenant', function () {
    Tenant::first()->makeCurrent();

    dispatch(new TestJob());

    return Tenant::checkCurrent() ? 'active tenant' : 'no tenant';
});

Route::get('no-tenant', function () {
    dispatch(new TestJob());

    return Tenant::checkCurrent() ? 'active tenant' : 'no tenant';
});

class TestJob implements ShouldQueue, TenantAware
{
    public function handle()
    {
        echo Tenant::checkCurrent() ? 'active tenant' : 'no tenant';
    }
}
```

Visiting `/tenant` displays 'active tenant' and visiting `/no-tenant` displays 'no tenant', as you would expect. However, looking at the output of the queue worker, you will see `active tenant` followed by `active tenant` again.

Obviously this example is fairly contrived, but a queue job that sends emails or updates records could cause some trouble.

The simplest option would be listening for `JobProcessed` and forgetting the tenant there, but that causes problems when using the sync queue driver (as it forgets the tenant in the middle of your code). 

As such I have made the following changes:
* I have modified the payload callback very slightly. If the job is _not_ tenant aware, no `tenantId` key is added (exactly as before). However, if the job _is_ tenant aware, a `tenantId` key is _always_ added, though it may be null. When coming to retrieve the tenant when the job is popped from the queue, this makes it possible to tell the difference between jobs that are not tenant aware, and those that are, but where no tenant was set at dispatch time.
* When the job is processed, if there is a `tenantId` present in the payload (i.e. it is tenant aware), but that `tenantId` is null or non-existent, the active tenant is unset. This will prevent tenant aware jobs from accidentally running under a previous tenant.
* If there is no `tenantId` field at all, nothing happens. The active tenant is left as it was. I think this should be okay, as a non-tenant job should never be making any assumptions about the tenant anyway.

As an aside, I have also removed the check that returns early if `queues_are_tenant_aware_by_default` is false, as that appeared to be preventing the tenant being set even if the job implemented `TenantAware` (`$tenant->makeCurrent();` becomes an unreachable statement).

I don't _think_ this is a breaking change, the only behaviour that is different is that `tenantId` on the payload is now sometimes null instead of missing. 

I'm happy to make any changes if the maintainers would like any.