### PR TITLE
tenant:artisan search customizable using config

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -18,10 +18,10 @@ return [
 
     /*
      * These fields are used by tenant:artisan command to match one or more tenant
-     *
-     * Set to `null` to use only id
      */
-    'tenant_artisan_search_fields' => null,
+    'tenant_artisan_search_fields' => [
+        'id',
+    ],
 
     /*
      * These tasks will be performed when switching tenants.

--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -17,6 +17,13 @@ return [
     'tenant_finder' => null,
 
     /*
+     * These fields are used by tenant:artisan command to match one or more tenant
+     *
+     * Set to `null` to use only id
+     */
+    'tenant_artisan_search_fields' => null,
+
+    /*
      * These tasks will be performed when switching tenants.
      *
      * A valid task is any class that implements Spatie\Multitenancy\Tasks\SwitchTenantTask

--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -29,7 +29,7 @@ class TenantsArtisanCommand extends Command
                     ->each(fn ($field) => $query->orWhereIn($field, Arr::wrap($tenants)));
             });
 
-            if ($tenantQuery->count() == 0) {
+            if ($tenantQuery->count() === 0) {
                 $this->error('No tenant(s) found.');
                 return;
             }

--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -5,12 +5,13 @@ namespace Spatie\Multitenancy\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Artisan;
+use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
 use Spatie\Multitenancy\Models\Tenant;
 
 class TenantsArtisanCommand extends Command
 {
-    use UsesTenantModel;
+    use UsesTenantModel, UsesMultitenancyConfig;
 
     protected $signature = 'tenants:artisan {artisanCommand} {--tenant=*}';
 
@@ -22,8 +23,16 @@ class TenantsArtisanCommand extends Command
             $artisanCommand = $this->ask('Which artisan command do you want to run for all tenants?');
         }
 
-        if ($tenantIds = $this->option('tenant')) {
-            $tenantQuery->whereIn('id', Arr::wrap($tenantIds));
+        if ($tenants = $this->option('tenant')) {
+            $tenantQuery->where(function ($query) use ($tenants) {
+                collect($this->getTenantArtisanSearchFields())
+                    ->each(fn ($field) => $query->orWhereIn($field, Arr::wrap($tenants)));
+            });
+
+            if ($tenantQuery->count() == 0) {
+                $this->error('No tenant(s) found.');
+                return;
+            }
         }
 
         $tenantQuery

--- a/src/Concerns/UsesMultitenancyConfig.php
+++ b/src/Concerns/UsesMultitenancyConfig.php
@@ -39,6 +39,6 @@ trait UsesMultitenancyConfig
 
     public function getTenantArtisanSearchFields() : array
     {
-        return Arr::wrap(config('multitenancy.tenant_artisan_search_fields') ?? 'id');
+        return Arr::wrap(config('multitenancy.tenant_artisan_search_fields'));
     }
 }

--- a/src/Concerns/UsesMultitenancyConfig.php
+++ b/src/Concerns/UsesMultitenancyConfig.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Multitenancy\Concerns;
 
+use Illuminate\Support\Arr;
 use Spatie\Multitenancy\Exceptions\InvalidConfiguration;
 
 trait UsesMultitenancyConfig
@@ -34,5 +35,10 @@ trait UsesMultitenancyConfig
         }
 
         return app($configuredClass);
+    }
+
+    public function getTenantArtisanSearchFields() : array
+    {
+        return Arr::wrap(config('multitenancy.tenant_artisan_search_fields') ?? 'id');
     }
 }

--- a/tests/Feature/Commands/TenantsArtisanCommandTest.php
+++ b/tests/Feature/Commands/TenantsArtisanCommandTest.php
@@ -54,6 +54,27 @@ class TenantsArtisanCommandTest extends TestCase
             ->assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');
     }
 
+    /** @test */
+    public function it_cant_migrate_a_specific_tenant_id_when_search_by_domain()
+    {
+        config([ 'multitenancy.tenant_artisan_search_fields' => 'domain' ]);
+
+        $this->artisan('tenants:artisan migrate --tenant=' . $this->anotherTenant->id . '"')
+            ->expectsOutput("No tenant(s) found.");
+    }
+
+    /** @test */
+    public function it_can_migrate_a_specific_tenant_by_domain()
+    {
+        config([ 'multitenancy.tenant_artisan_search_fields' => 'domain' ]);
+
+        $this->artisan('tenants:artisan migrate --tenant=' . $this->anotherTenant->domain . '"')->assertExitCode(0);
+
+        $this
+            ->assertTenantDatabaseDoesNotHaveTable($this->tenant, 'migrations')
+            ->assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');
+    }
+
     protected function assertTenantDatabaseHasTable(Tenant $tenant, string $tableName): self
     {
         $tenantHasDatabaseTable = $this->tenantHasDatabaseTable($tenant, $tableName);


### PR DESCRIPTION
Hi, 

i know that isn't a priority to use "tenant:artisan" searching by domain, but now I think it could be merged.

Now it works by id (like past), or by your custom search fields from config file:
```php
'tenant_artisan_search_fields' => 'domain', // will search by domain
// OR
'tenant_artisan_search_fields' => [ 'id', 'domain' ], // will search by id or domain
// ...
```

If you identify your tenant using a custom field, it will work too:
```php
// ...
'tenant_artisan_search_fields' => 'host', // will search by any other column in tenant model
// ...
```