### PR TITLE
allow mass assignment when creating a new tenant by default

### DIFF
--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -12,6 +12,8 @@ class Tenant extends Model
 {
     use UsesLandlordConnection;
 
+    protected $guarded = [];
+
     public function makeCurrent(): self
     {
         $this
@@ -34,7 +36,7 @@ class Tenant extends Model
     {
         $containerKey = config('multitenancy.current_tenant_container_key');
 
-        if (! app()->has($containerKey)) {
+        if (!app()->has($containerKey)) {
             return null;
         }
 


### PR DESCRIPTION
Hi,

It seems by default that the below doesn't work, should this be changed?

```php
$tenant = Tenant::create([
  'name' => 'tenantX-name',
  'domain' => 'tenantX-domain',
  'database' => 'tenantX-database'
]);
```