### PR TITLE
Change database default connection if needed

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -59,6 +59,12 @@ return [
     'landlord_database_connection_name' => null,
 
     /*
+     * Using `\Spatie\Multitenancy\Tasks\SwitchTenantDatabaseTask`, could be useful to
+     * set up the tenant database connection as default connection.
+     */
+    'tenant_database_connection_as_default' => false,
+
+    /*
      * This key will be used to bind the current tenant in the container.
      */
     'current_tenant_container_key' => 'currentTenant',

--- a/src/Concerns/UsesMultitenancyConfig.php
+++ b/src/Concerns/UsesMultitenancyConfig.php
@@ -17,6 +17,11 @@ trait UsesMultitenancyConfig
         return config('multitenancy.landlord_database_connection_name') ?? config('database.default');
     }
 
+    public function tenantDatabaseConnectionAsDefault(): bool
+    {
+        return config('multitenancy.tenant_database_connection_as_default') ?? false;
+    }
+
     public function currentTenantContainerKey(): string
     {
         return config('multitenancy.current_tenant_container_key');

--- a/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
+++ b/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Multitenancy\Tests\Feature\Tasks;
 
 use Illuminate\Support\Facades\DB;
 use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Tasks\PrefixCacheTask;
 use Spatie\Multitenancy\Tasks\SwitchTenantDatabaseTask;
 use Spatie\Multitenancy\Tests\TestCase;
 
@@ -33,12 +34,32 @@ class SwitchTenantDatabaseTest extends TestCase
 
         $this->assertEquals('laravel_mt_tenant_1', DB::connection('tenant')->getDatabaseName());
 
+        $this->assertEquals(config('database.default'), 'landlord');
+
         $this->anotherTenant->makeCurrent();
 
         $this->assertEquals('laravel_mt_tenant_2', DB::connection('tenant')->getDatabaseName());
 
+        $this->assertEquals(config('database.default'), 'landlord');
+
         Tenant::forgetCurrent();
 
         $this->assertNull(DB::connection('tenant')->getDatabaseName());
+    }
+
+    /** @test */
+    public function when_making_a_tenant_current_switch_the_default_connection_if_needed()
+    {
+        $this->assertEquals(config('database.default'), 'landlord');
+
+        config()->set('multitenancy.tenant_database_connection_as_default', true);
+
+        $this->tenant->makeCurrent();
+
+        $this->assertEquals(config('database.default'), 'tenant');
+
+        Tenant::forgetCurrent();
+
+        $this->assertEquals(config('database.default'), 'landlord');
     }
 }


### PR DESCRIPTION
Using packages like Laravel Passport or Laravel Sanctum (and many others) could be useful to switch the default database connection to "tenant" instead of "landlord".

Using the config file, now it is merely possible:

```php
/*
 * Using `\Spatie\Multitenancy\Tasks\SwitchTenantDatabaseTask`, could be useful to
 * set up the tenant database connection as default connection.
 */
'tenant_database_connection_as_default' => true,
```



