### PR TITLE
Added `$tenant->execute($callable)` to execute isolated tenant code

### DIFF
--- a/docs/advanced-usage/tenant-isolated-environment.md
+++ b/docs/advanced-usage/tenant-isolated-environment.md
@@ -3,9 +3,10 @@ title: Tenant isolated environment
 weight: 9
 ---
 
-If you need to execute tenant-code, without setting it as current, you can use the method `execute` available in the `Tenant` model: it will create an isolated environment valid only for the callable code.
+To execute tenant-code, without setting it as current, you can use the method `execute` available in the `Tenant` model. It will create an isolated environment valid only for the callable code.
 
-For example, let's say we need to flush the cache for a tenant using our landlord API:
+Here is an example where we flush the cache for a tenant using our landlord API:
+
 ```php
 Route::delete('/api/{tenant}/flush-cache', static function (Tenant $tenant) {
     $result = $tenant->execute(fn (Tenant $tenant) => cache()->flush());
@@ -14,7 +15,8 @@ Route::delete('/api/{tenant}/flush-cache', static function (Tenant $tenant) {
 });
 ```
 
-Another scenario is when you need to work with a tenant, but you have already a tenant up:
+Another scenario is when you need to work with a tenant, but you have already another tenant as the current one:
+
 ```php
 $currentTenant = \Spatie\Multitenancy\Models\Tenant::where('domain', 'example-tenant-1.spatie.be')->first();
 $currentTenant->makeCurrent();
@@ -31,7 +33,7 @@ echo cache()->get('used_at') . PHP_EOL; // Returns: '1987-02-21'
 echo $beta_used_at . PHP_EOL; // Returns: '2020-02-21'
 ```
 
-Or, more simple, dispatch a job tenant-aware from our landlord API route:
+Here's a final example, where a job is dispatched from our landlord API route:
 ```php
 Route::post('/api/{tenant}/reminder', function (Tenant $tenant) {
     return json_encode([ 

--- a/docs/advanced-usage/tenant-isolated-environment.md
+++ b/docs/advanced-usage/tenant-isolated-environment.md
@@ -8,9 +8,9 @@ If you need to execute tenant-code, without setting it as current, you can use t
 For example, let's say we need to flush the cache for a tenant using our landlord API:
 ```php
 Route::delete('/api/{tenant}/flush-cache', static function (Tenant $tenant) {
-   $result = $tenant->execute(fn (Tenant $tenant) => cache()->flush());
+    $result = $tenant->execute(fn (Tenant $tenant) => cache()->flush());
    
-   return json_encode([ "success" => $result ]);
+    return json_encode([ "success" => $result ]);
 });
 ```
 
@@ -21,11 +21,11 @@ $currentTenant->makeCurrent();
 cache()->set('used_at', '1987-02-21');
 
 $beta_used_at = \Spatie\Multitenancy\Models\Tenant::query()
-  ->where('domain', 'example-tenant-2.spatie.be')
-  ->first()
-  ->execute(static function (Tenant $tenant) {
+    ->where('domain', 'example-tenant-2.spatie.be')
+    ->first()
+    ->execute(function (Tenant $tenant) {
         return tap('2020-02-21', fn ($used_at) => cache()->set('used_at', $used_at));
-  }); 
+    }); 
   
 echo cache()->get('used_at') . PHP_EOL; // Returns: '1987-02-21'
 echo $beta_used_at . PHP_EOL; // Returns: '2020-02-21'
@@ -33,8 +33,9 @@ echo $beta_used_at . PHP_EOL; // Returns: '2020-02-21'
 
 Or, more simple, dispatch a job tenant-aware from our landlord API route:
 ```php
-Route::post('/api/{tenant}/reminder', static function (Tenant $tenant) {
-   dispatch(ExpirationReminder());
-   return json_encode([ 'success' => true ]);
+Route::post('/api/{tenant}/reminder', function (Tenant $tenant) {
+    return json_encode([ 
+        'data' => $tenant->run(fn () => dispatch(ExpirationReminder())),
+    ]);
 });
 ```

--- a/docs/advanced-usage/tenant-isolated-environment.md
+++ b/docs/advanced-usage/tenant-isolated-environment.md
@@ -22,18 +22,19 @@ $currentTenant = \Spatie\Multitenancy\Models\Tenant::where('domain', 'example-te
 $currentTenant->makeCurrent();
 cache()->set('used_at', '1987-02-21');
 
-$beta_used_at = \Spatie\Multitenancy\Models\Tenant::query()
+$betaUsedAt = \Spatie\Multitenancy\Models\Tenant::query()
     ->where('domain', 'example-tenant-2.spatie.be')
     ->first()
     ->execute(function (Tenant $tenant) {
         return tap('2020-02-21', fn ($used_at) => cache()->set('used_at', $used_at));
     }); 
   
-echo cache()->get('used_at') . PHP_EOL; // Returns: '1987-02-21'
-echo $beta_used_at . PHP_EOL; // Returns: '2020-02-21'
+cache()->get('used_at'); // returns '1987-02-21'
+$betaUsedAt; // returns '2020-02-21'
 ```
 
-Here's a final example, where a job is dispatched from our landlord API route:
+Here's a final example, where a job is dispatched from a landlord API route:
+
 ```php
 Route::post('/api/{tenant}/reminder', function (Tenant $tenant) {
     return json_encode([ 

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -76,7 +76,7 @@ class Tenant extends Model
         return new TenantCollection($models);
     }
 
-    public function run(callable $callable)
+    public function execute(callable $callable)
     {
         $originalCurrentTenant = Tenant::current();
 

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -75,4 +75,17 @@ class Tenant extends Model
     {
         return new TenantCollection($models);
     }
+
+    public function run(callable $callable)
+    {
+        $originalCurrentTenant = Tenant::current();
+
+        $this->makeCurrent();
+
+        return tap($callable($this), static function () use ($originalCurrentTenant) {
+            $originalCurrentTenant
+                ? $originalCurrentTenant->makeCurrent()
+                : Tenant::forgetCurrent();
+        });
+    }
 }

--- a/src/TenantCollection.php
+++ b/src/TenantCollection.php
@@ -19,17 +19,7 @@ class TenantCollection extends Collection
 
     protected function performCollectionMethodWhileMakingTenantsCurrent(string $operation, callable $callable): self
     {
-        $originalCurrentTenant = Tenant::current();
-
-        $collection = $this->$operation(function (Tenant $tenant) use ($callable) {
-            $tenant->makeCurrent();
-
-            return $callable($tenant);
-        });
-
-        $originalCurrentTenant
-            ? $originalCurrentTenant->makeCurrent()
-            : Tenant::forgetCurrent();
+        $collection = $this->$operation(fn (Tenant $tenant) => $tenant->run($callable));
 
         return new static($collection->items);
     }

--- a/src/TenantCollection.php
+++ b/src/TenantCollection.php
@@ -19,7 +19,7 @@ class TenantCollection extends Collection
 
     protected function performCollectionMethodWhileMakingTenantsCurrent(string $operation, callable $callable): self
     {
-        $collection = $this->$operation(fn (Tenant $tenant) => $tenant->run($callable));
+        $collection = $this->$operation(fn (Tenant $tenant) => $tenant->execute($callable));
 
         return new static($collection->items);
     }

--- a/tests/Feature/Models/TenantTest.php
+++ b/tests/Feature/Models/TenantTest.php
@@ -141,13 +141,13 @@ class TenantTest extends TestCase
     }
 
     /** @test */
-    public function it_will_runs_a_callable_and_then_restore_the_previous_state()
+    public function it_will_execute_a_callable_and_then_restore_the_previous_state()
     {
         Tenant::forgetCurrent();
 
         $this->assertNull(Tenant::current());
 
-        $response = $this->tenant->run(function (Tenant $tenant) {
+        $response = $this->tenant->execute(function (Tenant $tenant) {
             $this->assertEquals($tenant->id, Tenant::current()->id);
 
             return $tenant->id;

--- a/tests/Feature/Models/TenantTest.php
+++ b/tests/Feature/Models/TenantTest.php
@@ -139,4 +139,22 @@ class TenantTest extends TestCase
         Event::assertNotDispatched(ForgettingCurrentTenantEvent::class);
         Event::assertNotDispatched(ForgotCurrentTenantEvent::class);
     }
+
+    /** @test */
+    public function it_will_runs_a_callable_and_then_restore_the_previous_state()
+    {
+        Tenant::forgetCurrent();
+
+        $this->assertNull(Tenant::current());
+
+        $response = $this->tenant->run(function (Tenant $tenant) {
+            $this->assertEquals($tenant->id, Tenant::current()->id);
+
+            return $tenant->id;
+        });
+
+        $this->assertNull(Tenant::current());
+
+        $this->assertEquals($response, $this->tenant->id);
+    }
 }


### PR DESCRIPTION
I have added a `$tenant->execute($callable)` method to the `Tenant` model to allow the execution of isolated tenant code.

Here an example:

```php
$tenant = Tenant::where('domain', 'my-fake-tenant.spatie.be')->first();
$result = $tenant->execute(fn (Tenant $tenant) => cache()->flush());

if ($result) {
    echo "The cache for {$tenant->name} has been flushed". PHP_EOL;
} else {
    echo "I'm sorry, but something went wrong. Try again!" . PHP_EOL;
}

// no tenant selected here...
```