### PR TITLE
Feature landlord execute

### DIFF
--- a/docs/advanced-usage/isolated-environment.md
+++ b/docs/advanced-usage/isolated-environment.md
@@ -1,8 +1,11 @@
 ---
-title: Tenant isolated environment
+title: Isolated environment
 weight: 9
 ---
 
+Working with the multi-tenant environment often requires to execute isolated-code: for example, to dispatch a job reserved to a tenant from the landlord website, and vice-versa. 
+
+### Tenant isolated environment
 To execute tenant-code, without setting it as current, you can use the method `execute` available in the `Tenant` model. It will create an isolated environment valid only for the callable code.
 
 Here is an example where we flush the cache for a tenant using our landlord API:
@@ -40,5 +43,19 @@ Route::post('/api/{tenant}/reminder', function (Tenant $tenant) {
     return json_encode([ 
         'data' => $tenant->run(fn () => dispatch(ExpirationReminder())),
     ]);
+});
+```
+
+### Landlord isolated environment
+To execute landlord-code, from a tenant website for example, you can use the method `execute` available in the `Spatie\Multitenancy\Landlord` class. It will create an isolated environment valid only for the callable code.
+
+Here is an example where from a tenant we will clear the tenant cache, and next the landlord cache:
+```php
+Tenant::first()->execute(function (Tenant $tenant) {
+    // it will clear the tenant cache
+    Artisan::call('cache:clear'); 
+   
+    // it will clear the landlord cache
+    \Spatie\Multitenancy\Landlord::execute(fn () => Artisan::call('cache:clear')); 
 });
 ```

--- a/src/Landlord.php
+++ b/src/Landlord.php
@@ -10,9 +10,11 @@ class Landlord
         $originalCurrentTenant = Tenant::current();
 
         Tenant::forgetCurrent();
-
-        $callable();
+        
+        $result = $callable();
         
         optional($originalCurrentTenant)->makeCurrent();
+        
+        return $result;
     }
 }

--- a/src/Landlord.php
+++ b/src/Landlord.php
@@ -11,6 +11,8 @@ class Landlord
 
         Tenant::forgetCurrent();
 
-        return tap($callable(), fn () => optional($originalCurrentTenant)->makeCurrent());
+        $callable();
+        
+        optional($originalCurrentTenant)->makeCurrent();
     }
 }

--- a/src/Landlord.php
+++ b/src/Landlord.php
@@ -1,0 +1,16 @@
+<?php
+namespace Spatie\Multitenancy;
+
+use Spatie\Multitenancy\Models\Tenant;
+
+class Landlord
+{
+    public static function execute(callable $callable)
+    {
+        $originalCurrentTenant = Tenant::current();
+
+        Tenant::forgetCurrent();
+
+        return tap($callable(), fn () => optional($originalCurrentTenant)->makeCurrent());
+    }
+}

--- a/tests/Feature/LandlordTest.php
+++ b/tests/Feature/LandlordTest.php
@@ -21,13 +21,9 @@ class LandlordTest extends TestCase
     {
         $this->tenant->makeCurrent();
 
-        $response = Landlord::execute(function () {
-            $this->assertNull(Tenant::current());
+        $response = Landlord::execute(fn () => Tenant::current());
 
-            return "landlord";
-        });
-
-        $this->assertEquals($response, "landlord");
+        $this->assertNull($response);
 
         $this->assertEquals($this->tenant->id, Tenant::current()->id);
     }

--- a/tests/Feature/LandlordTest.php
+++ b/tests/Feature/LandlordTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace Spatie\Multitenancy\Tests\Feature;
+
+use Spatie\Multitenancy\Landlord;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Tests\TestCase;
+
+class LandlordTest extends TestCase
+{
+    private Tenant $tenant;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tenant = factory(Tenant::class)->create();
+    }
+
+    /** @test */
+    public function it_will_execute_a_callable_as_landlord_and_then_restore_the_previous_tenant()
+    {
+        $this->tenant->makeCurrent();
+
+        $response = Landlord::execute(function () {
+            $this->assertNull(Tenant::current());
+
+            return "landlord";
+        });
+
+        $this->assertEquals($response, "landlord");
+
+        $this->assertEquals($this->tenant->id, Tenant::current()->id);
+    }
+}


### PR DESCRIPTION
Like for the isolated tenant environment, I have built the same feature for the landlord.

Now it's possible to execute landlord-code in a tenant environment:
```php
Landlord::execute(fn () => dispatch(LandlordJob()));
// or
Landlord::execute(fn () => Artisan::call('cache:clear'));
```