### PR TITLE
Database switch fails with misconfigured tenant

### DIFF
--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -15,7 +15,7 @@ class InvalidConfiguration extends Exception
     /** @test */
     public static function tenantConnectionIsEmptyOrEqualsToLandlordConnection(): self
     {
-        return new static("`SwitchTenantDatabaseTask` fails because `multitenancy.tenant_database_connection_name` is `null` or equals to `multitenancy.tenant_database_connection_name`.");
+        return new static("`SwitchTenantDatabaseTask` fails because `multitenancy.tenant_database_connection_name` is `null` or equals to `multitenancy.landlord_database_connection_name`.");
     }
 
     public static function invalidAction(string $actionName, string $configuredClass, string $actionClass): self

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -12,6 +12,12 @@ class InvalidConfiguration extends Exception
         return new static("Could not find a tenant connection named `{$expectedConnectionName}`. Make sure to create a connection with that name in the `connections` key of the `database` config file.");
     }
 
+    /** @test */
+    public static function tenantConnectionIsEmptyOrEqualsToLandlordConnection(): self
+    {
+        return new static("`SwitchTenantDatabaseTask` fails because `multitenancy.tenant_database_connection_name` is `null` or equals to `multitenancy.tenant_database_connection_name`.");
+    }
+
     public static function invalidAction(string $actionName, string $configuredClass, string $actionClass): self
     {
         return new static("The class currently specified in the `multitenancy.actions.{$actionName}` key '{$configuredClass}' should be or extend `{$actionClass}`.");

--- a/src/Tasks/SwitchTenantDatabaseTask.php
+++ b/src/Tasks/SwitchTenantDatabaseTask.php
@@ -25,6 +25,10 @@ class SwitchTenantDatabaseTask implements SwitchTenantTask
     {
         $tenantConnectionName = $this->tenantDatabaseConnectionName();
 
+        if ($tenantConnectionName === $this->landlordDatabaseConnectionName()) {
+            throw InvalidConfiguration::tenantConnectionIsEmptyOrEqualsToLandlordConnection();
+        }
+
         if (is_null(config("database.connections.{$tenantConnectionName}"))) {
             throw InvalidConfiguration::tenantConnectionDoesNotExist($tenantConnectionName);
         }

--- a/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
+++ b/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Multitenancy\Tests\Feature\Tasks;
 
 use Illuminate\Support\Facades\DB;
+use Spatie\Multitenancy\Exceptions\InvalidConfiguration;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tasks\SwitchTenantDatabaseTask;
 use Spatie\Multitenancy\Tests\TestCase;
@@ -22,6 +23,16 @@ class SwitchTenantDatabaseTest extends TestCase
         $this->anotherTenant = factory(Tenant::class)->create(['database' => 'laravel_mt_tenant_2']);
 
         config()->set('multitenancy.switch_tenant_tasks', [SwitchTenantDatabaseTask::class]);
+    }
+
+    /** @test */
+    public function switch_fails_if_tenant_database_connection_name_equals_to_landlord_connection_name()
+    {
+        config()->set('multitenancy.tenant_database_connection_name', null);
+
+        $this->expectException(InvalidConfiguration::class);
+
+        $this->tenant->makeCurrent();
     }
 
     /** @test */


### PR DESCRIPTION
Using `SwitchTenantDatabaseTask` it's better to have two different connection names between landlord and tenant.

To avoid a misconfiguration, I have added an exception throws when tenant `multitenancy.tenant_database_connection_name` is the same of `multitenancy.landlord_database_connection_name`.

Related issue: https://github.com/spatie/laravel-multitenancy/issues/90