### PR TITLE
TenantAware should use the tenant model...

### DIFF
--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -4,19 +4,20 @@ namespace Spatie\Multitenancy\Commands\Concerns;
 
 use Illuminate\Support\Arr;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
-use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 trait TenantAware
 {
     use UsesMultitenancyConfig;
+    use UsesTenantModel;
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $tenants = Arr::wrap($this->option('tenant'));
 
-        $tenantQuery = Tenant::query()
+        $tenantQuery = $this->getTenantModel()::query()
             ->when(! blank($tenants), function ($query) use ($tenants) {
                 collect($this->getTenantArtisanSearchFields())
                     ->each(fn ($field) => $query->orWhereIn($field, Arr::wrap($tenants)));

--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -10,8 +10,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait TenantAware
 {
-    use UsesMultitenancyConfig;
-    use UsesTenantModel;
+    use UsesMultitenancyConfig,
+        UsesTenantModel;
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {


### PR DESCRIPTION
I believe that the TenantAware trait for the tenant artisan command should use the configured tenant model.

I haven't run any tests (other than seeing it work when I make the changes locally)....I'm editing it directly in github.  If there are issues, then I'll clone and try to do it "properly".  ;-)