### PR TITLE
Forget current when making new tenant current...

### DIFF
--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -14,6 +14,12 @@ class Tenant extends Model
 
     public function makeCurrent(): self
     {
+        if ($this->isCurrent()) {
+            return $this;
+        }
+
+        static::forgetCurrent();
+
         $this
             ->getMultitenancyActionClass('make_tenant_current_action', MakeTenantCurrentAction::class)
             ->execute($this);


### PR DESCRIPTION
I'm not 100% sure that this change is a good idea.  It makes sense to me for what I *think* would be good, in general.  I'm not sure, however, because this is my first jaunt down Multi-Tenancy Lane.  ;-)

Anyway, this small change does two things on calls to `makeCurrent()`:
- First, it will return early if the tenant is already the current.
- Second, it will call `forgetCurrent()` for the "old" tenant.

Please let me know what's good about this and, more importantly, what's bad with this and why.  :-)

Thx.