### PR TITLE
Removed check isCurrent from makeCurrent

### DIFF
--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -14,10 +14,6 @@ class Tenant extends Model
 
     public function makeCurrent(): self
     {
-        if ($this->isCurrent()) {
-            return $this;
-        }
-
         static::forgetCurrent();
 
         $this


### PR DESCRIPTION
It resolves a bug introduced by #111 PR.

Using a job to execute an Artisan command (`Artisan::call(...)`, the Tenant is supplied, but Laravel resets the configuration applied by the tasks. To solve the problem, I removed the lines from 17 to 20 from `Tenant` model.

