### PR TITLE
Fix for broken doc links

### DIFF
--- a/docs/advanced-usage/listening-for-events.md
+++ b/docs/advanced-usage/listening-for-events.md
@@ -7,22 +7,22 @@ The package fires events where you can listen for to perform some extra logic.
 
 ## `\Spatie\Multitenancy\Events\MakingTenantCurrentEvent`
 
-This event will fire when a tenant is being made the current one. At this point none of [the tasks](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed. 
+This event will fire when a tenant is being made the current one. At this point none of [the tasks](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed.
 
 It has one public property `$tenant`, that contains an instance of `Spatie\Multitenancy\Models\Tenant`
 
 ## `\Spatie\Multitenancy\Events\MadeTenantCurrentEvent`
 
-This event will fire when a tenant has been made the current one. At this point the `makeCurrent` method of all of [the tasks](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed. The current tenant also have been bound as `currentTenant` in the container.
+This event will fire when a tenant has been made the current one. At this point the `makeCurrent` method of all of [the tasks](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed. The current tenant also have been bound as `currentTenant` in the container.
 
 It has one public property `$tenant`, that contains an instance of `Spatie\Multitenancy\Models\Tenant`
 
 ## `\Spatie\Multitenancy\Events\ForgettingCurrentTenantEvent`
 
-This event will fire when a tenant is being forgotten. At this point none of [the tasks](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed. 
+This event will fire when a tenant is being forgotten. At this point none of [the tasks](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed.
 
 It has one public property `$tenant`, that contains an instance of `Spatie\Multitenancy\Models\Tenant`
 
 ## `\Spatie\Multitenancy\Events\ForgotCurrentTenantEvent`
 
-This event will fire when a tenant has been forgotten. At this point the `forgotCurrent` method of all of [the tasks](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed. `currentTenant` in the container has been emptied.
+This event will fire when a tenant has been forgotten. At this point the `forgotCurrent` method of all of [the tasks](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) have been executed. `currentTenant` in the container has been emptied.

--- a/docs/basic-usage/working-with-the-current-tenant.md
+++ b/docs/basic-usage/working-with-the-current-tenant.md
@@ -35,7 +35,7 @@ You can manually make a tenant the current one by calling `makeCurrent()` on it.
 $tenant->makeCurrent();
 ```
 
-When a tenant is made the current one, the package will run the `makeCurrent` method of [all tasks configured](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) in the `switch_tenant_tasks` key of the `multitenancy` config file.
+When a tenant is made the current one, the package will run the `makeCurrent` method of [all tasks configured](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) in the `switch_tenant_tasks` key of the `multitenancy` config file.
 
 
 ### Forgetting the current tenant

--- a/docs/installation/base-installation.md
+++ b/docs/installation/base-installation.md
@@ -89,7 +89,7 @@ return [
         'make_queue_tenant_aware_action' => MakeQueueTenantAwareAction::class,
         'migrate_tenant' => MigrateTenantAction::class,
     ],
-];   
+];
 ```
 
 ### Protecting against cross tenant abuse
@@ -134,12 +134,10 @@ Route::middleware('tenant')->group(function() {
 });
 ```
 
-This middleware will respond with an unauthorized response code (401) when the user tries to use their session to view another tenant. Make sure to include `\Spatie\Multitenancy\Http\Middleware\NeedsTenant` first, as this will [handle any cases where a valid tenant cannot be found](/laravel-multitenancy/v1/advanced-usage/ensuring-a-current-tenant-has-been-set).
+This middleware will respond with an unauthorized response code (401) when the user tries to use their session to view another tenant. Make sure to include `\Spatie\Multitenancy\Http\Middleware\NeedsTenant` first, as this will [handle any cases where a valid tenant cannot be found](/docs/laravel-multitenancy/v1/advanced-usage/ensuring-a-current-tenant-has-been-set).
 
 ### Next steps
 
-If you prefer to use just one glorious database for all your tenants, read the installation instructions for [using a single database](/laravel-multitenancy/v1/installation/using-a-single-database). 
+If you prefer to use just one glorious database for all your tenants, read the installation instructions for [using a single database](/docs/laravel-multitenancy/v1/installation/using-a-single-database).
 
-If you want to use separate databases for each tenant, head over to the installation instructions for [using multiple databases](/laravel-multitenancy/v1/installation/using-multiple-databases). 
-
-
+If you want to use separate databases for each tenant, head over to the installation instructions for [using multiple databases](/docs/laravel-multitenancy/v1/installation/using-multiple-databases).

--- a/docs/installation/determining-current-tenant.md
+++ b/docs/installation/determining-current-tenant.md
@@ -19,4 +19,4 @@ To use that tenant finder, specify its class name in the `tenant_finder` key of 
 'tenant_finder' => Spatie\Multitenancy\TenantFinder\DomainTenantFinder::class,
 ```
 
-If you want to determine the "current" tenant some other way, you can [create a custom tenant finder](/laravel-multitenancy/v1/basic-usage/automatically-determining-the-current-tenant/).
+If you want to determine the "current" tenant some other way, you can [create a custom tenant finder](/docs/laravel-multitenancy/v1/basic-usage/automatically-determining-the-current-tenant/).

--- a/docs/installation/using-a-single-database.md
+++ b/docs/installation/using-a-single-database.md
@@ -3,13 +3,13 @@ title: Using a single database
 weight: 2
 ---
 
-Before using the following instructions, make sure you have performed [the base installation steps](/laravel-multitenancy/v1/installation/base-installation) first.
- 
+Before using the following instructions, make sure you have performed [the base installation steps](/docs/laravel-multitenancy/v1/installation/base-installation) first.
+
  Only use the instructions on this page if you want use one database.
 
 ### Migrating the database
 
-With the database connection set up we can migrate the landlord database. 
+With the database connection set up we can migrate the landlord database.
 
 First, you must publish and run the migration:
 
@@ -22,6 +22,6 @@ This will create the `tenants` table which holds configuration per tenant.
 
 ### Next steps
 
-When using multiple tenants, you probably want to [isolate the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache/) or use your own separated filesystems per tenant, ... These things are performed by [task classes](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) that will be executed when making a tenant the current one.
+When using multiple tenants, you probably want to [isolate the cache](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache/) or use your own separated filesystems per tenant, ... These things are performed by [task classes](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) that will be executed when making a tenant the current one.
 
-The package also has an option to [make the queue tenant aware](/laravel-multitenancy/v1/basic-usage/making-queues-tenant-aware/).
+The package also has an option to [make the queue tenant aware](/docs/laravel-multitenancy/v1/basic-usage/making-queues-tenant-aware/).

--- a/docs/installation/using-multiple-databases.md
+++ b/docs/installation/using-multiple-databases.md
@@ -3,7 +3,7 @@ title: Using multiple databases
 weight: 3
 ---
 
-Before using the following instructions, make sure you have performed [the base installation steps](/laravel-multitenancy/v1/installation/base-installation) first.
+Before using the following instructions, make sure you have performed [the base installation steps](/docs/laravel-multitenancy/v1/installation/base-installation) first.
 
 Only use the instructions on this page if you want each of your tenants to have their own database.
 
@@ -37,7 +37,7 @@ In the example below, the `mysql` driver is used, but you can use any driver you
 
 ### Migrating the landlord database
 
-With the database connection set up we can migrate the landlord database. 
+With the database connection set up we can migrate the landlord database.
 
 First, you must publish the migration file:
 
@@ -50,7 +50,7 @@ The command above will publish a migration in `database/migrations/landlord` tha
 Perform this command to run that migration. The value of database option should be the landlord database connection name.
 
 ```bash
-php artisan migrate --path=database/migrations/landlord --database=landlord 
+php artisan migrate --path=database/migrations/landlord --database=landlord
 ```
 
 When creating new migrations that should be performed on the landlord database, you should store them in the `database/migrations/landlord` path. After creating your own migrations, use the command above to migrate the landlord database.
@@ -74,11 +74,11 @@ You should add this task to the `switch_tenant_tasks` key.
 ],
 ```
 
-The package also provides [other tasks](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) that you could optionally add to `switch_tenant_tasks`. You can also [create a custom task](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/).
+The package also provides [other tasks](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/overview/) that you could optionally add to `switch_tenant_tasks`. You can also [create a custom task](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/).
 
 ### Creating tenant databases
 
-Now that automatic database switching for tenants is configured, you can migrate the tenant databases. Because there are so many ways to go about it, the package does not handle creating databases. You should take care of creating new tenant databases in your own application code. A nice place to trigger this could be [when a `Tenant` model gets created](/laravel-multitenancy/v1/advanced-usage/using-a-custom-tenant-model/#performing-actions-when-a-tenant-gets-created).
+Now that automatic database switching for tenants is configured, you can migrate the tenant databases. Because there are so many ways to go about it, the package does not handle creating databases. You should take care of creating new tenant databases in your own application code. A nice place to trigger this could be [when a `Tenant` model gets created](/docs/laravel-multitenancy/v1/advanced-usage/using-a-custom-tenant-model/#performing-actions-when-a-tenant-gets-created).
 
 If you want to get a feel of how the package works, you could create a couple of rows in the `tenants` table, fill the `database` attribute and manually create those databases.
 
@@ -86,7 +86,7 @@ If you want to get a feel of how the package works, you could create a couple of
 
 When you want to migrate tenant databases, all future migrations should be stored in `database/migrations`.
 
-To perform these migrations, you can use [the `tenants:migrate` command](/laravel-multitenancy/v1/advanced-usage/executing-artisan-commands-for-each-tenant). This command will loop over all rows in the `tenants` table. It will make each tenant the current one, and migrate the database.
+To perform these migrations, you can use [the `tenants:migrate` command](/docs/laravel-multitenancy/v1/advanced-usage/executing-artisan-commands-for-each-tenant). This command will loop over all rows in the `tenants` table. It will make each tenant the current one, and migrate the database.
 
 ```bash
 php artisan tenants:artisan "migrate --database=tenant"
@@ -114,7 +114,7 @@ class DatabaseSeeder extends Seeder
            ? $this->runTenantSpecificSeeders()
            : $this->runLandlordSpecificSeeders();
     }
-    
+
     public function runTenantSpecificSeeders()
     {
         // run tenant specific seeders
@@ -133,4 +133,4 @@ All models in your project should either use the `UsesLandLordConnection` or `Us
 
 ### Next steps
 
-When using multiple tenants, you probably want to [isolate the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache/) or [use separate filesystems per tenant](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/filesystem/), ... These things are performed by task classes that will be executed when making a tenant the current one.
+When using multiple tenants, you probably want to [isolate the cache](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache/) or [use separate filesystems per tenant](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/filesystem/), ... These things are performed by task classes that will be executed when making a tenant the current one.

--- a/docs/using-tasks-to-prepare-the-environment/overview.md
+++ b/docs/using-tasks-to-prepare-the-environment/overview.md
@@ -5,13 +5,13 @@ weight: 1
 
 When making a tenant the current one, the tasks inside the `switch_tenant_tasks` key of the `multitenancy` config file will be executed. Inside these tasks you can perform logic to configure the environment for the tenant that is being made the current one.
 
-The philosophy of this package is that it should only provide the bare essentials to enable multitenancy. That's why it only provides two tasks out of the box. These tasks serve as example implementations.  
+The philosophy of this package is that it should only provide the bare essentials to enable multitenancy. That's why it only provides two tasks out of the box. These tasks serve as example implementations.
 
-You can easily [create your own tasks](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/) that fit your particular project.
+You can easily [create your own tasks](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/) that fit your particular project.
 
 The package ships with these tasks:
 
-- [switch the tenant database](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/switching-databases) (required when using multiple tenant databases)
-- [prefixing the cache](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache)
+- [switch the tenant database](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/switching-databases) (required when using multiple tenant databases)
+- [prefixing the cache](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/prefixing-cache)
 
 These tasks are optional. When you need one, just add it to the `switch_tenant_tasks` key of the `multitenancy` config file.

--- a/docs/using-tasks-to-prepare-the-environment/prefixing-cache.md
+++ b/docs/using-tasks-to-prepare-the-environment/prefixing-cache.md
@@ -41,4 +41,4 @@ cache('key') // returns 'value-for-another-tenant'
 
 Behind the scenes, this works by dynamically changing the `cache.prefix` in the `cache` config file whenever another tenant is made current.
 
-If you want to make the cache tenant aware in another way, you should [create your own task](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/). You can take a look at the source code of `PrefixCacheTask` for inspiration.
+If you want to make the cache tenant aware in another way, you should [create your own task](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/). You can take a look at the source code of `PrefixCacheTask` for inspiration.

--- a/docs/using-tasks-to-prepare-the-environment/switching-databases.md
+++ b/docs/using-tasks-to-prepare-the-environment/switching-databases.md
@@ -16,4 +16,4 @@ To use this task, you should add it to the `switch_tenant_tasks` key in the `mul
 ],
 ```
 
-If you want to change other database connection properties beside the database name, you should [create your own task](/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/). You can take a look at the source code of `SwitchTenantDatabaseTask` for inspiration.
+If you want to change other database connection properties beside the database name, you should [create your own task](/docs/laravel-multitenancy/v1/using-tasks-to-prepare-the-environment/creating-your-own-task/). You can take a look at the source code of `SwitchTenantDatabaseTask` for inspiration.


### PR DESCRIPTION
This PR includes updates to links in the docs that reference itself, it seems the new version of the docs design breaks links within itself.

Perhaps updating the reference in whatever generates the docs on the frontend to include `/docs/` for any internal reference, or just use this PR.

For example:
1. Go to https://spatie.be/docs/laravel-multitenancy/v1/installation/using-multiple-databases
2. Click the text `the base installation steps` link which leads to `https://spatie.be/laravel-multitenancy/v1/installation/base-installation`
3. 404 page.