### PR TITLE
Add ability to dispatch events tenant aware

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -94,6 +94,8 @@ class MakeQueueTenantAwareAction
                 return $queueable->notification;
             case CallQueuedListener::class:
                 return $queueable->class;
+            case BroadcastEvent::class:
+                return $queueable->event;
             default:
                 return $queueable;
         }


### PR DESCRIPTION
Digging inside the #139 issue, I found that using [`YourEvent::dispatch()`](https://laravel.com/docs/8.x/events#dispatching-events) the job didn't recognized by `MakeQueueTenantAwareAction`.

This PR allows the package to recognize if the job dispatched is of the `BroadcastEvent` type, and enables the ability to use the interfaces `TenantAware` and `NotTenantAware` for the events.