### PR TITLE
Removed @test annotations from the exception class

### DIFF
--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -6,13 +6,11 @@ use Exception;
 
 class InvalidConfiguration extends Exception
 {
-    /** @test */
     public static function tenantConnectionDoesNotExist(string $expectedConnectionName): self
     {
         return new static("Could not find a tenant connection named `{$expectedConnectionName}`. Make sure to create a connection with that name in the `connections` key of the `database` config file.");
     }
 
-    /** @test */
     public static function tenantConnectionIsEmptyOrEqualsToLandlordConnection(): self
     {
         return new static("`SwitchTenantDatabaseTask` fails because `multitenancy.tenant_database_connection_name` is `null` or equals to `multitenancy.landlord_database_connection_name`.");


### PR DESCRIPTION
Hi there!

I was making a lightweight version of this package for a project and spotted this. It looks like some `@test` annotations ended up in the source code.