### PR TITLE
Fix for duplicate test

### DIFF
--- a/tests/Feature/TenantFinder/DomainTenantFinderTest.php
+++ b/tests/Feature/TenantFinder/DomainTenantFinderTest.php
@@ -39,6 +39,8 @@ class DomainTenantFinderTest extends TestCase
     /** @test */
     public function it_will_return_null_if_no_tenant_can_be_found_for_the_current_domain()
     {
+        $tenant = factory(Tenant::class)->create(['domain' => 'my-domain.com']);
+
         $request = Request::create('https://another-domain.com');
 
         $this->assertNull($this->tenantFinder->findForRequest($request));


### PR DESCRIPTION
I noticed this test is exactly the same as the one before it, and it appears it is just missing creating a tenant with a different domain than the one in the request to show, as the name of the test says, that `it_will_return_null_if_no_tenant_can_be_found_for_the_current_domain`