### PR TITLE
NeedsTenant should able to return or redirect

### DIFF
--- a/src/Http/Middleware/NeedsTenant.php
+++ b/src/Http/Middleware/NeedsTenant.php
@@ -19,7 +19,7 @@ class NeedsTenant
         return $next($request);
     }
 
-    public function handleInvalidRequest(): void
+    public function handleInvalidRequest()
     {
         throw NoCurrentTenant::make();
     }


### PR DESCRIPTION
The `NeedsTenant` middleware `handleInvalidRequest` should not be restricted to a void return value. It should be able to produce a redirect or a view to display an error message.