### PR TITLE
Add support for executing delayed callbacks in Tenant context

### DIFF
--- a/docs/advanced-usage/executing-code-for-tenants-and-landlords.md
+++ b/docs/advanced-usage/executing-code-for-tenants-and-landlords.md
@@ -30,7 +30,18 @@ Route::post('/api/{tenant}/reminder', function (Tenant $tenant) {
     ]);
 });
 ```
+### Executing a delayed callback in the correct Tenant context
+If you need to define a callback that will be executed in the correct Tenant context every time it is called, you can use the Tenant's `callback` method.
+A notable example for this is the use in the Laravel scheduler where you can loop through all the tenants and schedule callbacks to be executed at the given time:
 
+```php
+protected function schedule(Schedule $schedule)
+{
+    Tenant::all()->eachCurrent(function(Tenant $tenant) use ($schedule) {
+        $schedule->run($tenant->callback(fn() => cache()->flush()))->daily();
+    });
+}
+```
 
 ## Executing landlord code in tenant request
 

--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -92,4 +92,9 @@ class Tenant extends Model
                 : Tenant::forgetCurrent();
         });
     }
+
+    public function callback(callable $callable): \Closure
+    {
+        return fn() => $this->execute($callable);
+    }
 }

--- a/tests/Feature/Models/TenantTest.php
+++ b/tests/Feature/Models/TenantTest.php
@@ -157,4 +157,26 @@ class TenantTest extends TestCase
 
         $this->assertEquals($response, $this->tenant->id);
     }
+
+    /** @test */
+    public function it_will_execute_a_delayed_callback_in_tenant_context()
+    {
+        Tenant::forgetCurrent();
+
+        $this->assertNull(Tenant::current());
+
+        $callback = $this->tenant->callback(function (Tenant $tenant) {
+            $this->assertEquals($tenant->id, Tenant::current()->id);
+
+            return $tenant->id;
+        });
+
+        $this->assertNull(Tenant::current());
+
+        $response = $callback();
+
+        $this->assertNull(Tenant::current());
+
+        $this->assertEquals($response, $this->tenant->id);
+    }
 }


### PR DESCRIPTION
I have added a commit for allowing delayed callbacks to be executed inside of the Tenant context. It is useful in case when callbacks are defined in the Tenant context but their execution takes place outside of it. One notable example of this use case is the Laravel scheduler.

For example, the following code inside the `schedule()` function won't work correctly, because even though the callback is defined in the tenant context, it is simply being added to the queue and is executed after the `schedule()` function terminates:

```php
Tenant::all()->eachCurrent(function(Tenant $tenant) use ($schedule){
    $schedule->run(fn() => /*do something*/)->Daily();
})
```

With this proposal, the desired behavior can be achieved like this

```php
Tenant::all()->eachCurrent(function(Tenant $tenant) use ($schedule){
    $schedule->run($tenant->callback(fn() => /*do something*/))->Daily();
})
```

This will make sure the code inside the callback is executed inside the correct Tenant's context. 