### PR TITLE
Upgrade version of laravel-package-tools in composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-multitenancy` will be documented in this file
 
+## 2.0.1 - 2021-03-16
+
+- upgrade dependency version of laravel-package-tools in composer.json
+
 ## 2.0.0 - 2021-03-12
 
 - drop support for PHP 7

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^8.0",
-        "spatie/laravel-package-tools": "^1.5"
+        "spatie/laravel-package-tools": "^1.6"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",


### PR DESCRIPTION
This PR upgrades the version of Laravel Package Tools in the composer.json file.

This change is required so we can retrieve the latest fix that was merged to the spatie/laravel-package-tools project here: https://github.com/spatie/laravel-package-tools/pull/23