### PR TITLE
Add tenant scope to improve the single-database mode

### DIFF
--- a/src/Models/Concerns/BelongsToTenant.php
+++ b/src/Models/Concerns/BelongsToTenant.php
@@ -4,7 +4,10 @@ namespace Spatie\Multitenancy\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Multitenancy\Exceptions\NoCurrentTenant;
 use Spatie\Multitenancy\Models\Concerns\Scopes\TenantScope;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Multitenancy;
 
 /** @mixin Model */
 trait BelongsToTenant
@@ -12,6 +15,14 @@ trait BelongsToTenant
     public static function bootedBelongsToTenant(): void
     {
         static::addGlobalScope(new TenantScope());
+
+        static::creating(function (Model $model) {
+            $tenantForeignKey = app(Multitenancy::class)
+                ->getTenantModel()
+                ->getForeignKey();
+
+            $model->{$tenantForeignKey} ??= Tenant::current()?->getKey();
+        });
     }
 
     public function tenant(): BelongsTo

--- a/src/Models/Concerns/BelongsToTenant.php
+++ b/src/Models/Concerns/BelongsToTenant.php
@@ -4,7 +4,6 @@ namespace Spatie\Multitenancy\Models\Concerns;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Spatie\Multitenancy\Exceptions\NoCurrentTenant;
 use Spatie\Multitenancy\Models\Concerns\Scopes\TenantScope;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Multitenancy;
@@ -12,7 +11,7 @@ use Spatie\Multitenancy\Multitenancy;
 /** @mixin Model */
 trait BelongsToTenant
 {
-    public static function bootedBelongsToTenant(): void
+    public static function bootBelongsToTenant(): void
     {
         static::addGlobalScope(new TenantScope());
 

--- a/src/Models/Concerns/BelongsToTenant.php
+++ b/src/Models/Concerns/BelongsToTenant.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\Multitenancy\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Spatie\Multitenancy\Models\Concerns\Scopes\TenantScope;
+
+/** @mixin Model */
+trait BelongsToTenant
+{
+    public static function bootedBelongsToTenant(): void
+    {
+        static::addGlobalScope(new TenantScope());
+    }
+
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(config('multitenancy.tenant_model'));
+    }
+}
+
+

--- a/src/Models/Concerns/Scopes/TenantScope.php
+++ b/src/Models/Concerns/Scopes/TenantScope.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spatie\Multitenancy\Models\Concerns\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Spatie\Multitenancy\Exceptions\NoCurrentTenant;
+use Spatie\Multitenancy\Models\Tenant;
+
+class TenantScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        if (! $tenant = Tenant::current()) {
+            throw new NoCurrentTenant();
+        }
+
+        $builder->where($tenant->getForeignKey(), $tenant->getKey());
+    }
+}


### PR DESCRIPTION
🚧 Work in progress: code not tested 🚧

The package has a lot of features for the multi-database mode but is poor with the single mode. 

The feature improves our support to the single-mode with a `TenantScope` and a trait `BelongsToTenant`. 

For example, imagine a model `Setting` that belongs to a Tenant.

```php
class Setting extends Model
{
    use BelongsToTenant;
}
``` 

Now, calling the class from your code, the tenant foreign key will always be present: and the same will be when you create a new `Setting`.

Finally, if for any coding reason you need to remove the global scope, you can use the Laravel feature:
```php
Setting::withoutGlobalScope(TenantScope::class)->get()
```

@freekmurze what do you think about it? I will create the tests and the documentation if is ok for you.
