### PR TITLE
Describe option that does *not* default to all tenants...

### DIFF
--- a/docs/advanced-usage/making-artisan-commands-tenant-aware.md
+++ b/docs/advanced-usage/making-artisan-commands-tenant-aware.md
@@ -3,7 +3,9 @@ title: Making Artisan command tenant aware
 weight: 3
 ---
 
-Commands can be made tenant aware by applying the `TenantAware` trait. When using the trait it is required to append `{--tenant=*}` to the command signature.
+Commands can be made tenant aware by applying the `TenantAware` trait. When using the trait it is required to append `{--tenant=*}` or `{--tenant=}` to the command signature.
+
+Caution: If you append `{--tenant=*}`, then if no `tenant` option is provided when executing the command, the command will execute for *all* tenants.
  
 ```php
 use Illuminate\Console\Command;


### PR DESCRIPTION
I wanted to update the docs to reflect the difference between requiring a specified tenant versus allowing for **all** tenants to be specified by default.

I'm not sure if this is correct/possible/advisable/whatever, but I ran into the problem when creating a very destructive command that I want to use carefully.  I don't want to accidentally run the command against all tenants by simply forgetting to specify a particular tenant.  I changed the signature to use `{--tenant=}` instead of `{--tenant=*}` and it appears to work as expected.  That is, it **requires** a tenant to be specified if none is provided.

Hopefully the use case makes sense and hopefully the use of `{--tenant=}` instead of `{--tenant=*}` is OK.  Please let me know if I'm wrong.

I also changed the docs quickly, so it may not be worded well or thorough enough.  I figured more effort could be put into it once I got the green light from Spatie that this was a reasonable change/use. 🤓

I look forward to your feedback...