### PR TITLE
[EMPHASYS] Updating language term to improve action

### DIFF
--- a/docs/installation/using-multiple-databases.md
+++ b/docs/installation/using-multiple-databases.md
@@ -24,13 +24,13 @@ In the example below, the `mysql` driver is used, but you can use any driver you
     'tenant' => [
         'driver' => 'mysql',
         'database' => null,
-        // other options such as host, username, password, ...
+        // DON'T forget to include host, username, password, and other options if needed ...
     ],
 
     'landlord' => [
         'driver' => 'mysql',
         'database' => 'name_of_landlord_db',
-        // other options such as host, username, password, ...
+        // DON'T forget to include host, username, password, and other options if needed ...
     ],
 ```
 

--- a/docs/installation/using-multiple-databases.md
+++ b/docs/installation/using-multiple-databases.md
@@ -24,13 +24,19 @@ In the example below, the `mysql` driver is used, but you can use any driver you
     'tenant' => [
         'driver' => 'mysql',
         'database' => null,
-        // DON'T forget to include host, username, password, and other options if needed ...
+        'host' => '127.0.0.1',
+        'username' => 'userTenantDbUser',
+        'password' => '',
+        // And other options if needed ...
     ],
 
     'landlord' => [
         'driver' => 'mysql',
         'database' => 'name_of_landlord_db',
-        // DON'T forget to include host, username, password, and other options if needed ...
+        'host' => '127.0.0.1',
+        'username' => 'userLandlordDbUser',
+        'password' => '',
+        // And other options if needed ...
     ],
 ```
 


### PR DESCRIPTION
Not include the remaining database configuration can return errors on the migration next steps. Making Host, User, and Password mandatory on the documentation can move the user to not forget to include this required information and avoid any support requirement related to DB connection.