### PR TITLE
Handle `JobRetryRequested` queue event and fix #259

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -3,6 +3,7 @@
 namespace Spatie\Multitenancy\Actions;
 
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobRetryRequested;
 use Illuminate\Support\Arr;
 use Spatie\Multitenancy\Exceptions\CurrentTenantCouldNotBeDeterminedInTenantAwareJob;
 use Spatie\Multitenancy\Jobs\NotTenantAware;
@@ -18,7 +19,8 @@ class MakeQueueTenantAwareAction
     {
         $this
             ->listenForJobsBeingQueued()
-            ->listenForJobsBeingProcessed();
+            ->listenForJobsBeingProcessed()
+            ->listenForJobsRetryRequested();
     }
 
     protected function listenForJobsBeingQueued(): self
@@ -49,6 +51,19 @@ class MakeQueueTenantAwareAction
         return $this;
     }
 
+    protected function listenForJobsRetryRequested(): self
+    {
+        app('events')->listen(JobRetryRequested::class, function (JobRetryRequested $event) {
+            if (!array_key_exists('tenantId', $event->payload())) {
+                return;
+            }
+
+            $this->findTenant($event)->makeCurrent();
+        });
+
+        return $this;
+    }
+
     protected function isTenantAware(object $queueable): bool
     {
         $reflection = new \ReflectionClass($this->getJobFromQueueable($queueable));
@@ -64,9 +79,18 @@ class MakeQueueTenantAwareAction
         return config('multitenancy.queues_are_tenant_aware_by_default') === true;
     }
 
-    protected function findTenant(JobProcessing $event): Tenant
+    protected function getEventPayload($event): ?array
     {
-        $tenantId = $event->job->payload()['tenantId'];
+        return match (true) {
+            $event instanceof JobProcessing => $event->job->payload(),
+            $event instanceof JobRetryRequested => $event->payload(),
+            default => null,
+        };
+    }
+
+    protected function findTenant(JobProcessing|JobRetryRequested $event): Tenant
+    {
+        $tenantId = $this->getEventPayload($event)['tenantId'] ?? null;
 
         if (! $tenantId) {
             $event->job->delete();


### PR DESCRIPTION
* listenForJobsRetryRequested method has been added and executed
* Because JobProcessing and JobRetryRequested has no shared interface a new getEventPayload method has been presented to be able to extract the payload from incompatible classes
* findTenant modified to be able to get the payload correctly