### PR TITLE
[Proposal] Issue templating

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Ask a question
+      url: https://github.com/spatie/laravel-multitenancy/discussions/new?category=q-a
+      about: Ask the community for help
+    - name: Request a feature
+      url: https://github.com/spatie/laravel-multitenancy/discussions/new?category=ideas
+      about: Share ideas for new features
+    - name: Report a bug
+      url: https://github.com/spatie/laravel-multitenancy/issues/new
+      about: Report a reproducable bug


### PR DESCRIPTION
Hi dears, 

to improve our repository organization I think is better to introduce the issue templating offered by GitHub.

Any new issue will show a screen like so:
<img width="1245" alt="example" src="https://user-images.githubusercontent.com/6555012/144412204-b95253a7-2aad-4299-924f-a432a6cc5a60.png">

It will help the users to use the discussions instead of issues for questions and ideas.

What do you think about it?
