### PR TITLE
docs: change method visibility in example

### DIFF
--- a/docs/advanced-usage/using-a-custom-tenant-model.md
+++ b/docs/advanced-usage/using-a-custom-tenant-model.md
@@ -29,7 +29,7 @@ use Spatie\Multitenancy\Models\Tenant;
 
 class CustomTenantModel extends Tenant
 {
-    public static function booted()
+    protected static function booted()
     {
         static::creating(fn(CustomTenantModel $model) => $model->createDatabase());
     }


### PR DESCRIPTION
Cause method visibility shouldn't be overridden.
Original is `protected`

https://github.com/laravel/framework/blob/2246744061de4bfd2d3a42d715e6b760015fa074/src/Illuminate/Database/Eloquent/Model.php#L298-L308