### PR TITLE
docs: Updated custom tenant model

### DIFF
--- a/docs/advanced-usage/using-a-custom-tenant-model.md
+++ b/docs/advanced-usage/using-a-custom-tenant-model.md
@@ -13,7 +13,7 @@ You should specify the class name of your model in the `tenant_model` key of the
  *
  * It must be or extend `Spatie\Multitenancy\Models\Tenant::class`
  */
-'tenant_model' => \App\Models\CustomTenantModel::class,
+'tenant_model' => \App\Models\Tenant\CustomTenantModel::class,
 ```
 
 ## Performing actions when a tenant gets created
@@ -29,6 +29,8 @@ use Spatie\Multitenancy\Models\Tenant;
 
 class CustomTenantModel extends Tenant
 {
+    protected $table = 'tenants';
+
     protected static function booted()
     {
         static::creating(fn(CustomTenantModel $model) => $model->createDatabase());


### PR DESCRIPTION
### Description

Updating documentation related to using a custom tenant model. I've overridden `$table` property on model, as it'd by default point to `custom_tenant` table. 

And updated config reference to match the namespace in the example.