### PR TITLE
Fix cached routes

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -69,6 +69,12 @@ return [
      */
     'current_tenant_container_key' => 'currentTenant',
 
+    /**
+     * Set it to `true` if you like to cache the tenant(s) routes
+     * in a shared file using the `SwitchRouteCacheTask`.
+     */
+    'shared_routes_cache' => false,
+
     /*
      * You can customize some of the behavior of this package by using our own custom action.
      * Your custom action should always extend the default one.

--- a/src/Tasks/SwitchRouteCacheTask.php
+++ b/src/Tasks/SwitchRouteCacheTask.php
@@ -11,7 +11,7 @@ class SwitchRouteCacheTask implements SwitchTenantTask
     {
         Env::getRepository()->set('APP_ROUTES_CACHE', $this->getCachedRoutesPath($tenant));
 
-        if (isset($_SERVER['LARAVEL_OCTANE']) && app()->routesAreCached()) {
+        if (app()->routesAreCached() && $this->shouldReinitializeRouter()) {
             // Laravel Octane will load the routes cache only once when initializing the application.
             // To undo this and reload the proper route cache based of `APP_ROUTES_CACHE`, we need to reinitialize the `Router`.
 
@@ -27,5 +27,12 @@ class SwitchRouteCacheTask implements SwitchTenantTask
     protected function getCachedRoutesPath(Tenant $tenant): string
     {
         return "bootstrap/cache/routes-v7-tenant-{$tenant->id}.php";
+    }
+
+    protected function shouldReinitializeRouter(): bool
+    {
+        return isset($_SERVER['LARAVEL_OCTANE'])
+            || app()->runningInConsole()
+            || app()->runningUnitTests();
     }
 }

--- a/tests/Feature/Tasks/SwitchRouteCacheTaskTest.php
+++ b/tests/Feature/Tasks/SwitchRouteCacheTaskTest.php
@@ -16,7 +16,7 @@ class SwitchRouteCacheTaskTest extends TestCase
     }
 
     /** @test */
-    public function it_will_use_a_different_routes_cache_environment_variable_for_each_tenant()
+    public function it_will_use_a_different_routes_cache_environment_variable_for_each_tenant(): void
     {
         /** @var \Spatie\Multitenancy\Models\Tenant $tenant */
         $tenant = Tenant::factory()->create();
@@ -33,6 +33,25 @@ class SwitchRouteCacheTaskTest extends TestCase
 
         $anotherTenant->makeCurrent();
         $this->assertEquals("bootstrap/cache/routes-v7-tenant-{$anotherTenant->id}.php", env('APP_ROUTES_CACHE'));
+
+        Tenant::forgetCurrent();
+        $this->assertNull(env('APP_ROUTES_CACHE'));
+    }
+
+    /** @test */
+    public function it_will_use_a_shared_routes_cache_environmnet_variable_for_all_tenants(): void
+    {
+        config()->set('multitenancy.shared_routes_cache', true);
+
+        /** @var \Spatie\Multitenancy\Models\Tenant $tenant */
+        $tenant = Tenant::factory()->create();
+        $tenant->makeCurrent();
+        $this->assertEquals("bootstrap/cache/routes-v7-tenants.php", env('APP_ROUTES_CACHE'));
+
+        /** @var \Spatie\Multitenancy\Models\Tenant $anotherTenant */
+        $anotherTenant = Tenant::factory()->create();
+        $anotherTenant->makeCurrent();
+        $this->assertEquals("bootstrap/cache/routes-v7-tenants.php", env('APP_ROUTES_CACHE'));
 
         Tenant::forgetCurrent();
         $this->assertNull(env('APP_ROUTES_CACHE'));


### PR DESCRIPTION
The PR fixes a bug when the package is running in a console environment (tinker too) or unit tests and introduces the configurable ability to create only one routes cache file instead of a file for each tenant.
