### PR TITLE
Refresh connection resolver for models after switching database and fix cache prefixes not being updated

### DIFF
--- a/src/Tasks/PrefixCacheTask.php
+++ b/src/Tasks/PrefixCacheTask.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Multitenancy\Tasks;
 
+use Illuminate\Support\Facades\Cache;
 use Spatie\Multitenancy\Models\Tenant;
 
 class PrefixCacheTask implements SwitchTenantTask
@@ -34,5 +35,12 @@ class PrefixCacheTask implements SwitchTenantTask
         config()->set('cache.prefix', $prefix);
 
         app('cache')->forgetDriver($this->storeName);
+
+        // This is important because the `CacheManager` will have the `$app['config']` array cached
+        // with old prefixes on the `cache` instance. Simply calling `forgetDriver` only removes
+        // the `$store` but doesn't update the `$app['config']`.
+        app()->forgetInstance('cache');
+
+        Cache::clearResolvedInstances();
     }
 }

--- a/src/Tasks/SwitchTenantDatabaseTask.php
+++ b/src/Tasks/SwitchTenantDatabaseTask.php
@@ -46,6 +46,7 @@ class SwitchTenantDatabaseTask implements SwitchTenantTask
 
         DB::purge($tenantConnectionName);
 
+        // Octane will have an old `db` instance in the Model::$resolver.
         Model::setConnectionResolver(app('db'));
     }
 }

--- a/src/Tasks/SwitchTenantDatabaseTask.php
+++ b/src/Tasks/SwitchTenantDatabaseTask.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Multitenancy\Tasks;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Spatie\Multitenancy\Exceptions\InvalidConfiguration;

--- a/src/Tasks/SwitchTenantDatabaseTask.php
+++ b/src/Tasks/SwitchTenantDatabaseTask.php
@@ -45,5 +45,7 @@ class SwitchTenantDatabaseTask implements SwitchTenantTask
         });
 
         DB::purge($tenantConnectionName);
+
+        Model::setConnectionResolver(app('db'));
     }
 }

--- a/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
+++ b/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
@@ -7,6 +7,7 @@ use Spatie\Multitenancy\Exceptions\InvalidConfiguration;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tasks\SwitchTenantDatabaseTask;
 use Spatie\Multitenancy\Tests\TestCase;
+use Spatie\Multitenancy\Tests\TestClasses\User;
 
 class SwitchTenantDatabaseTest extends TestCase
 {
@@ -43,10 +44,14 @@ class SwitchTenantDatabaseTest extends TestCase
         $this->tenant->makeCurrent();
 
         $this->assertEquals('laravel_mt_tenant_1', DB::connection('tenant')->getDatabaseName());
+        $this->assertEquals('laravel_mt_tenant_1', app(User::class)->getConnection()->getDatabaseName());
+
+        app()->forgetInstance('db'); // simulates a new Octane request
 
         $this->anotherTenant->makeCurrent();
 
         $this->assertEquals('laravel_mt_tenant_2', DB::connection('tenant')->getDatabaseName());
+        $this->assertEquals('laravel_mt_tenant_2', app(User::class)->getConnection()->getDatabaseName());
 
         Tenant::forgetCurrent();
 

--- a/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
+++ b/tests/Feature/Tasks/SwitchTenantDatabaseTest.php
@@ -46,8 +46,6 @@ class SwitchTenantDatabaseTest extends TestCase
         $this->assertEquals('laravel_mt_tenant_1', DB::connection('tenant')->getDatabaseName());
         $this->assertEquals('laravel_mt_tenant_1', app(User::class)->getConnection()->getDatabaseName());
 
-        app()->forgetInstance('db'); // simulates a new Octane request
-
         $this->anotherTenant->makeCurrent();
 
         $this->assertEquals('laravel_mt_tenant_2', DB::connection('tenant')->getDatabaseName());


### PR DESCRIPTION
# Refresh connection resolver for models after switching database

`Model::$resolver` contains a `db` instance with a database name. After switching to a different database, the `db` instance in the `Model::$resolver` should also be updated to the newly configured `db` instance. This fixes route model binding on Laravel Octane.

# Fix cache prefixes not being updated

Simply calling `Cache::forgetDriver()` isn't enough to update cache prefixes everywhere. The `CacheManager` also keeps a copy of the old config in `cache` and the `Cache` facade itself keeps an old copy of the `CacheManager`. All of these should be cleared and forgotten after switching cache configs.