### PR TITLE
Update create_landlord_tenants_table.php.stub

### DIFF
--- a/database/migrations/landlord/create_landlord_tenants_table.php.stub
+++ b/database/migrations/landlord/create_landlord_tenants_table.php.stub
@@ -12,7 +12,7 @@ class CreateLandlordTenantsTable extends Migration
             $table->id();
             $table->string('name');
             $table->string('domain')->unique();
-            $table->string('database')->unique();
+            $table->string('database')->index();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
A database can be shared between tenants. For instance `account.domain.com` and `domain.com` can share the same database.