### PR TITLE
Docs: fix the link to the video introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -11,4 +11,4 @@ Before starting with the package, we highly recommend first watching [this talk 
 
 The package contains a lot of niceties such as making queued jobs tenant aware, making an artisan command run for each tenant, an easy way to set a connection on a model, and much more.
 
-Are you a visual learner? Then watch [this video](https://spatie.be/videos/laravel-package-training/laravel-multitenancy) that covers how you can use laravel-multitenancy and how it works under the hood.
+Are you a visual learner? Then watch [this video](https://www.youtube.com/watch?v=1bucfsyAZtI) that covers how you can use laravel-multitenancy and how it works under the hood.


### PR DESCRIPTION
Not sure if that's the correct link, but the old link leads to "Page not found" on Spatie.be website.
That "Page not found" page, by the way, is also indexed on google by "laravel spatie multi tenancy", so you may want to do something with that page, too.