### PR TITLE
Change return type hint for `Tenant` class from `self` to `static`

### DIFF
--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -14,7 +14,7 @@ class Tenant extends Model
     use UsesLandlordConnection;
     use HasFactory;
 
-    public function makeCurrent(): self
+    public function makeCurrent(): static
     {
         if ($this->isCurrent()) {
             return $this;
@@ -32,7 +32,7 @@ class Tenant extends Model
         return $this;
     }
 
-    public function forget(): self
+    public function forget(): static
     {
         $this
             ->getMultitenancyActionClass(
@@ -44,7 +44,7 @@ class Tenant extends Model
         return $this;
     }
 
-    public static function current(): ?self
+    public static function current(): ?static
     {
         $containerKey = config('multitenancy.current_tenant_container_key');
 


### PR DESCRIPTION
## Description

This PR changes the return type hints of the various static constructor methods of the `Tenant` class from `self` to `static`.

## Rationale

In our project we extend the `Tenant` model to add a bunch of extra relations to it. Currently, the various static constructors use `self` as the return type hint. This leads to issues with static analysis since the return type will always point to the `Tenant` class from this package instead of our model. We end up having to do something like this all over the place.

```php
use App\Models\Tenant;

function someFunction(Tenant $tenant)
{
    // ...
}

// Leads to an error in phpstan since the function expects
// `App\Models\Tenant`, but got `Spatie\Multitenancy\Models\Tenant` instead.
//
// Note: null check ignored for brevity's sake.
someFunction(Tenant::current());

// Have to do this, instead.

/** @var Tenant $tenant */
$tenant = Tenant::current();

someFunction($tenant);
```