### PR TITLE
Prefix Cache Task - Cache Store

### DIFF
--- a/src/Tasks/PrefixCacheTask.php
+++ b/src/Tasks/PrefixCacheTask.php
@@ -41,6 +41,9 @@ class PrefixCacheTask implements SwitchTenantTask
         // the `$store` but doesn't update the `$app['config']`.
         app()->forgetInstance('cache');
 
+        //This is important because the Cache Repository is using an old version of the CacheManager
+        app()->forgetInstance('cache.store');
+
         Cache::clearResolvedInstances();
     }
 }

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -2,11 +2,9 @@
 
 namespace Spatie\Multitenancy\Tests\Feature\Tasks;
 
-use Illuminate\Support\Facades\Cache;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tasks\PrefixCacheTask;
 use Spatie\Multitenancy\Tests\TestCase;
-use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class PrefixCacheTaskTest extends TestCase
 {
@@ -28,28 +26,21 @@ class PrefixCacheTaskTest extends TestCase
     public function it_will_separate_the_cache_prefix_for_each_tenant()
     {
         $originalPrefix = config('cache.prefix').':';
-        $this->assertEquals($originalPrefix, cache()->getStore()->getPrefix());
         $this->assertEquals($originalPrefix, app('cache')->getPrefix());
-        $this->assertEquals($originalPrefix, app(CacheContract::class)->getPrefix());
         $this->assertEquals($originalPrefix, app('cache.store')->getPrefix());
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantOne = Tenant::factory()->create();
         $tenantOne->makeCurrent();
         $tenantOnePrefix = 'tenant_id_'.$tenantOne->id.':';
-
-        $this->assertEquals($tenantOnePrefix, cache()->getStore()->getPrefix());
         $this->assertEquals($tenantOnePrefix, app('cache')->getPrefix());
-        $this->assertEquals($tenantOnePrefix, app(CacheContract::class)->getPrefix());
         $this->assertEquals($tenantOnePrefix, app('cache.store')->getPrefix());
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantTwo = Tenant::factory()->create();
         $tenantTwo->makeCurrent();
         $tenantTwoPrefix = 'tenant_id_'.$tenantTwo->id.':';
-        $this->assertEquals($tenantTwoPrefix, cache()->getStore()->getPrefix());
         $this->assertEquals($tenantTwoPrefix, app('cache')->getPrefix());
-        $this->assertEquals($tenantTwoPrefix, app(CacheContract::class)->getPrefix());
         $this->assertEquals($tenantTwoPrefix, app('cache.store')->getPrefix());
     }
 
@@ -73,15 +64,11 @@ class PrefixCacheTaskTest extends TestCase
         cache()->put('key', $tenantTwoVal);
 
         $tenantOne->makeCurrent();
-        $this->assertEquals($tenantOneVal, cache()->get('key'));
         $this->assertEquals($tenantOneVal, app('cache')->get('key'));
-        $this->assertEquals($tenantOneVal, app(CacheContract::class)->get('key'));
         $this->assertEquals($tenantOneVal, app('cache.store')->get('key'));
 
         $tenantTwo->makeCurrent();
-        $this->assertEquals($tenantTwoVal, cache()->get('key'));
         $this->assertEquals($tenantTwoVal, app('cache')->get('key'));
-        $this->assertEquals($tenantTwoVal, app(CacheContract::class)->get('key'));
         $this->assertEquals($tenantTwoVal, app('cache.store')->get('key'));
 
         Tenant::forgetCurrent();

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -22,27 +22,27 @@ class PrefixCacheTaskTest extends TestCase
     /** @test */
     public function it_will_separate_the_cache_for_each_tenant()
     {
-        cache()->put('key', 'original-value');
+        cache()->put('key', 'cache-landlord');
 
-        /** @var \Spatie\Multitenancy\Models\Tenant $tenant */
-        $tenant = Tenant::factory()->create();
-        $tenant->makeCurrent();
+        /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
+        $tenantOne = Tenant::factory()->create();
+        $tenantOne->makeCurrent();
         $this->assertFalse(cache()->has('key'));
-        cache()->put('key', 'tenant-value');
+        cache()->put('key', 'tenant-one');
 
-        /** @var \Spatie\Multitenancy\Models\Tenant $anotherTenant */
-        $anotherTenant = Tenant::factory()->create();
-        $anotherTenant->makeCurrent();
+        /** @var \Spatie\Multitenancy\Models\Tenant $tenantTwo */
+        $tenantTwo = Tenant::factory()->create();
+        $tenantTwo->makeCurrent();
         $this->assertFalse(cache()->has('key'));
-        cache()->put('key', 'another-tenant-value');
+        cache()->put('key', 'tenant-two');
 
-        $tenant->makeCurrent();
-        $this->assertEquals('tenant-value', cache()->get('key'));
+        $tenantOne->makeCurrent();
+        $this->assertEquals('tenant-one', cache()->get('key'));
 
-        $anotherTenant->makeCurrent();
-        $this->assertEquals('another-tenant-value', cache()->get('key'));
+        $tenantTwo->makeCurrent();
+        $this->assertEquals('tenant-two', cache()->get('key'));
 
         Tenant::forgetCurrent();
-        $this->assertEquals('original-value', cache()->get('key'));
+        $this->assertEquals('cache-landlord', cache()->get('key'));
     }
 }

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -27,7 +27,9 @@ class PrefixCacheTaskTest extends TestCase
     {
         $originalPrefix = config('cache.prefix').':';
         $this->assertEquals($originalPrefix, cache()->getStore()->getPrefix());
+        $this->assertEquals($originalPrefix, app('cache')->getPrefix());
         $this->assertEquals($originalPrefix, app(CacheContract::class)->getPrefix());
+        $this->assertEquals($originalPrefix, app('cache.store')->getPrefix());
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantOne = Tenant::factory()->create();
@@ -35,14 +37,18 @@ class PrefixCacheTaskTest extends TestCase
         $tenantOnePrefix = 'tenant_id_'.$tenantOne->id.':';
 
         $this->assertEquals($tenantOnePrefix, cache()->getStore()->getPrefix());
+        $this->assertEquals($tenantOnePrefix, app('cache')->getPrefix());
         $this->assertEquals($tenantOnePrefix, app(CacheContract::class)->getPrefix());
+        $this->assertEquals($tenantOnePrefix, app('cache.store')->getPrefix());
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantTwo = Tenant::factory()->create();
         $tenantTwo->makeCurrent();
         $tenantTwoPrefix = 'tenant_id_'.$tenantTwo->id.':';
         $this->assertEquals($tenantTwoPrefix, cache()->getStore()->getPrefix());
+        $this->assertEquals($tenantTwoPrefix, app('cache')->getPrefix());
         $this->assertEquals($tenantTwoPrefix, app(CacheContract::class)->getPrefix());
+        $this->assertEquals($tenantTwoPrefix, app('cache.store')->getPrefix());
     }
 
     /** @test */
@@ -53,20 +59,28 @@ class PrefixCacheTaskTest extends TestCase
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantOne = Tenant::factory()->create();
         $tenantOne->makeCurrent();
+        $tenantOneVal = 'tenant-'.$tenantOne->domain;
         $this->assertFalse(cache()->has('key'));
-        cache()->put('key', 'tenant-one');
+        cache()->put('key', $tenantOneVal);
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantTwo */
         $tenantTwo = Tenant::factory()->create();
         $tenantTwo->makeCurrent();
+        $tenantTwoVal = 'tenant-'.$tenantTwo->domain;
         $this->assertFalse(cache()->has('key'));
-        cache()->put('key', 'tenant-two');
+        cache()->put('key', $tenantTwoVal);
 
         $tenantOne->makeCurrent();
-        $this->assertEquals('tenant-one', cache()->get('key'));
+        $this->assertEquals($tenantOneVal, cache()->get('key'));
+        $this->assertEquals($tenantOneVal, app('cache')->get('key'));
+        $this->assertEquals($tenantOneVal, app(CacheContract::class)->get('key'));
+        $this->assertEquals($tenantOneVal, app('cache.store')->get('key'));
 
         $tenantTwo->makeCurrent();
-        $this->assertEquals('tenant-two', cache()->get('key'));
+        $this->assertEquals($tenantTwoVal, cache()->get('key'));
+        $this->assertEquals($tenantTwoVal, app('cache')->get('key'));
+        $this->assertEquals($tenantTwoVal, app(CacheContract::class)->get('key'));
+        $this->assertEquals($tenantTwoVal, app('cache.store')->get('key'));
 
         Tenant::forgetCurrent();
         $this->assertEquals('cache-landlord', cache()->get('key'));

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -2,9 +2,11 @@
 
 namespace Spatie\Multitenancy\Tests\Feature\Tasks;
 
+use Illuminate\Support\Facades\Cache;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tasks\PrefixCacheTask;
 use Spatie\Multitenancy\Tests\TestCase;
+use Illuminate\Contracts\Cache\Repository as CacheContract;
 
 class PrefixCacheTaskTest extends TestCase
 {
@@ -25,16 +27,22 @@ class PrefixCacheTaskTest extends TestCase
     {
         $originalPrefix = config('cache.prefix').':';
         $this->assertEquals($originalPrefix, cache()->getStore()->getPrefix());
+        $this->assertEquals($originalPrefix, app(CacheContract::class)->getPrefix());
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantOne = Tenant::factory()->create();
         $tenantOne->makeCurrent();
-        $this->assertEquals('tenant_id_'.$tenantOne->id.':', cache()->getStore()->getPrefix());
+        $tenantOnePrefix = 'tenant_id_'.$tenantOne->id.':';
+
+        $this->assertEquals($tenantOnePrefix, cache()->getStore()->getPrefix());
+        $this->assertEquals($tenantOnePrefix, app(CacheContract::class)->getPrefix());
 
         /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
         $tenantTwo = Tenant::factory()->create();
         $tenantTwo->makeCurrent();
-        $this->assertEquals('tenant_id_'.$tenantTwo->id.':', cache()->getStore()->getPrefix());
+        $tenantTwoPrefix = 'tenant_id_'.$tenantTwo->id.':';
+        $this->assertEquals($tenantTwoPrefix, cache()->getStore()->getPrefix());
+        $this->assertEquals($tenantTwoPrefix, app(CacheContract::class)->getPrefix());
     }
 
     /** @test */

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -19,6 +19,24 @@ class PrefixCacheTaskTest extends TestCase
         cache()->flush();
     }
 
+
+    /** @test */
+    public function it_will_separate_the_cache_prefix_for_each_tenant()
+    {
+        $originalPrefix = config('cache.prefix').':';
+        $this->assertEquals($originalPrefix, cache()->getStore()->getPrefix());
+
+        /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
+        $tenantOne = Tenant::factory()->create();
+        $tenantOne->makeCurrent();
+        $this->assertEquals('tenant_id_'.$tenantOne->id.':', cache()->getStore()->getPrefix());
+
+        /** @var \Spatie\Multitenancy\Models\Tenant $tenantOne */
+        $tenantTwo = Tenant::factory()->create();
+        $tenantTwo->makeCurrent();
+        $this->assertEquals('tenant_id_'.$tenantTwo->id.':', cache()->getStore()->getPrefix());
+    }
+
     /** @test */
     public function it_will_separate_the_cache_for_each_tenant()
     {

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -18,7 +18,9 @@ class PrefixCacheTaskTest extends TestCase
 
         config()->set('cache.default', 'redis');
 
-        cache()->flush();
+        app()->forgetInstance('cache');
+
+        app()->forgetInstance('cache.store');
     }
 
 

--- a/tests/Feature/Tasks/PrefixCacheTaskTest.php
+++ b/tests/Feature/Tasks/PrefixCacheTaskTest.php
@@ -19,6 +19,8 @@ class PrefixCacheTaskTest extends TestCase
         app()->forgetInstance('cache');
 
         app()->forgetInstance('cache.store');
+
+        app('cache')->flush();
     }
 
 


### PR DESCRIPTION
I am using your package with the PrefixCacheTask along with the Unique Jobs feature on laravel and I have realised that the lock on the jobs does not get released.

The underline code of laravel is not using the Cache Manager but it's using the Cache Repository.

```
    protected function ensureUniqueJobLockIsReleased($command)
    {
         ....
        $cache = $this->container->make(Cache::class);

        $cache->lock(
            'laravel_unique_job:'.get_class($command).$uniqueId
        )->forceRelease();
    }
    
```

The Cache Repository holds an old version of the CacheManager which does not have the correct cache prefix and therefore none of the locks are deleted.