### PR TITLE
Authentication Based Multi-Tenancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",
-        "mockery/mockery": "^1.4",
+        "mockery/mockery": "^1.5",
         "orchestra/testbench": "^6.23|^7.0",
         "phpunit/phpunit": "^9.4",
         "spatie/valuestore": "^1.2",

--- a/docs/advanced-usage/authentication-aware-tenant-identification.md
+++ b/docs/advanced-usage/authentication-aware-tenant-identification.md
@@ -1,0 +1,124 @@
+---
+title: Authentication aware tenant identification
+weight: 10
+---
+
+Some projects will have their tenant based on a user attribute.
+
+By default, determining a tenant will happen at the very beginning of a request, even before routes and authentication are done. Utilize the tenantFinder at a later stage in the request by applying the `\Spatie\Multitenancy\Http\Middleware\DetermineTenant` middleware on those routes where authentication has already happened.
+
+## Base Installation
+
+Ensure the steps in [base installation](/docs/laravel-multitenancy/v2/installation/base-installation) have been completed with the fact that only some routes will be tenant aware in mind.
+
+## Create relation between users and tenant
+
+To identify a tenant from the User model, create a relation between the two.
+
+Create relation migration.
+
+```bash
+php artisan make:migration add_tenant_column_to_users
+```
+
+In the new migration file, create a relation between users and tenants.
+
+```php
+use Spatie\Multitenancy\Models\Tenant;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignIdFor(Tenant::class)->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('tenant_id');
+        });
+    }
+};
+```
+
+In users model, create eloquent relation indicating users belong to tenant.
+
+```php
+// in `app\Models\Users.php`
+use Spatie\Multitenancy\Models\Tenant;
+
+...
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+...
+```
+
+## Create custom tenant finder
+
+Create a tenant finder that returns the current tenant. Ensure it returns early if the user is not logged in.
+
+```php
+\\ In `app/Http/TenantFinder.php`
+namespace App\Http;
+
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\TenantFinder\TenantFinder as MultitenancyTenantFinder;
+use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
+
+use Illuminate\Http\Request;
+
+class TenantFinder extends MultitenancyTenantFinder
+{
+    use UsesTenantModel;
+
+    public function findForRequest(Request $request): ?Tenant
+    {
+        $tenantId = optional(auth()->user())->tenant_id;
+        if (!$tenantId) {
+            return null; // No tenant, no need to search db.
+        }
+        $tenant = $this->getTenantModel()->find($tenantId);
+        return $tenant;
+    }
+}
+
+```
+
+Configure tenant finder in multitenancy configuration.
+
+```php
+\\ In `app/Http/TenantFinder.php`
+
+...
+
+    'tenant_finder' => \App\Http\TenantFinder::class,
+
+...
+
+```
+
+
+## Add the middleware to tenant group
+
+Update tenant middleware group to include determination of tenant.
+
+```php
+// in `app\Http\Kernel.php`
+
+protected $middlewareGroups = [
+    // ...
+    'tenant' => [
+        \Spatie\Multitenancy\Http\Middleware\DetermineTenant::class,
+        \Spatie\Multitenancy\Http\Middleware\NeedsTenant::class
+    ]
+];
+```
+
+Ensure the tenant is determined prior to declaring need for tenant. Remove the `EnsureValidTenantSession` middleware, as your sessions are not separated by tenant, instead being dependent upon laravel authentication.

--- a/src/Http/Middleware/DetermineTenant.php
+++ b/src/Http/Middleware/DetermineTenant.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Multitenancy\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Spatie\Multitenancy\TenantFinder\TenantFinder;
+
+class DetermineTenant
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (! config('multitenancy.tenant_finder')) {
+            return;
+        }
+
+        $tenantFinder = app(TenantFinder::class);
+        $tenant = $tenantFinder->findForRequest($request);
+        optional($tenant)->makeCurrent();
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/Http/Middleware/DetermineTenantTest.php
+++ b/tests/Feature/Http/Middleware/DetermineTenantTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Mockery\MockInterface;
+use Spatie\Multitenancy\Http\Middleware\DetermineTenant;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\TenantFinder\TenantFinder;
+use Spatie\Multitenancy\Tests\TestCase;
+
+class DetermineTenantTest extends TestCase
+{
+    protected Request $request;
+    protected MockInterface $tenantFinderMock;
+    protected MockInterface $tenantMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        // Create a dummy request.
+        $this->request = $this->mock(Request::class);
+
+        // Set dumy configuration for tenantFinder.
+        config()->set('multitenancy.tenant_finder', TenantFinder::class);
+
+        // Setup mock tenant
+        $this->tenantMock = $this->mock(Tenant::class);
+        $this->tenantMock->shouldReceive('makeCurrent')->andReturnSelf();
+
+        // Setup a mock to check usage of TenantFinder.
+        $this->tenantFinderMock = $this->mock(TenantFinder::class);
+        $this->tenantFinderMock->shouldReceive('findForRequest')
+            ->withArgs([\Mockery::type(Request::class)])
+            ->andReturns($this->tenantMock);
+    }
+
+    /** @test */
+    public function it_skips_tenant_finder_on_missing_tenant_finder_setting(): void
+    {
+        // Nullify the tenantFinder class setting.
+        config()->set('multitenancy.tenant_finder', null);
+
+        // Run middleware handle method.
+        (new DetermineTenant())->handle($this->request, fn () => null);
+
+        // Ensure findForRequest was never called.
+        $this->tenantFinderMock->shouldNotHaveReceived('findForRequest');
+    }
+
+    /** @test */
+    public function it_calls_tenant_finder(): void
+    {
+        // Run middleware handle method.
+        (new DetermineTenant())->handle($this->request, fn () => null);
+
+        // Ensure it hit findForRequest.
+        $this->tenantFinderMock->shouldHaveReceived('findForRequest');
+    }
+
+    /** @test */
+    public function it_gracefully_handles_tenant_not_found()
+    {
+        // Return a null tenant on find tenant
+        $this->tenantFinderMock->shouldReceive('findForRequest')->andReturnNull();
+
+        // Mock expected response, so we get exceptions if they do anything on it.
+        $expectedResponseValue = $this->mock(Response::class);
+        $passedRequest = null;
+
+        // Run middleware handle method.
+        $returnedValue = (new DetermineTenant())->handle(
+            $this->request,
+            function (Request $request) use (&$passedRequest, $expectedResponseValue) {
+                $passedRequest = $request;
+
+                return $expectedResponseValue;
+            }
+        );
+
+        // Ensure request we passed in, matches the request passed to the callback.
+        $this->assertSame($this->request, $passedRequest, "Returned request is same as passed request.");
+        // Ensure request we passed in, matches the request returned from the callback.
+        $this->assertSame($expectedResponseValue, $returnedValue, "Returned request is same as passed request.");
+    }
+
+    /** @test */
+    public function it_makes_found_tenant_current()
+    {
+        // Run middleware handle method.
+        (new DetermineTenant())->handle($this->request, fn () => null);
+
+        // Ensure spy tenant had makeCurrent called on it.
+        $this->tenantMock->shouldHaveReceived('makeCurrent');
+    }
+}


### PR DESCRIPTION
This PR adds the middleware required for authentication based multi-tenancy, as well as documentation on how to use it.

### Example
#### Example of it's application utilizing the documentation:
https://github.com/kassah/multitenancy-pr-demo

The README in the repository covers demonstration steps.

#### Commit that makes the changes following documentation 
https://github.com/kassah/multitenancy-pr-demo/commit/84d9a80afd8505b9f83b85838b6cb9e661eca929

### Dependency Change
Increased the minimum version of Mockery, so that tests with mocks utilizing shouldNotHaveReceived could function without error.

### Why merge this feature add?
- Inspired by JetStream Teams and the possibility of being able to have a database per team. This is one step in that direction.
- The middleware recreates logic from deeper in this package, to best keep it in sync, I would like to see it apart of the upstream package.

#### Discussions this addresses:
- #389 
- #385 
- #378 
- #334 

#### Laracasts Discussions that seem to match the problem scope this PR is attempting to solve:
- https://laracasts.com/discuss/channels/general-discussion/multi-tenancy-with-multiple-databases
- https://laracasts.com/discuss/channels/general-discussion/app-architecture-feedback-multi-tenancy-multiple-data-centres
- https://laracasts.com/discuss/channels/general-discussion/multi-tenancy-with-separate-databases
- https://laracasts.com/discuss/channels/laravel/dynamic-multi-tenancy-best-practice
- https://laracasts.com/discuss/channels/general-discussion/is-my-application-considered-multi-tenancy

#### Incomplete internet tutorials
- https://mark.fullbrook.me/multi-tenant-databases-with-laravel-jetstream - At the end is specifically missing middleware code. - This is the first web page result when you Google for spatie multiteancy jetstream - https://www.google.com/search?q=Spatie+multitenancy+jetstream

### Requested Feedback
- Should I include more or less documentation? I was trying to strike a balance between showing the use of the middleware and giving them a step by step usage.
- Where would be good places to link to the new documentation. I didn't want to go around changing to much until this feature was overall deemed desirable.
- Middleware is currently reimplementing the same logic from the main `\Spatie\Multitenancy\Multitenancy::determineCurrentTenant` method, I'd love to reuse this method, however it's protected nature makes it inaccessible. Is there a recommended way to make these share code path? I'm especially interested in increasing the long term maintainability of the new middleware.
- The TenantFinder created in the documentation could easily be made into real classes with traits/interfaces for the User model. Is this desirable, or is it better to assume the user will customize this?
- Right now using this causes the TenantFinder to be called twice for each request. Once before routes are defined during the boot process, and later with this middleware. Ideas welcome for ways this can be reduced with configuration in a simple and backwards compatible way?

### Credits

Thanks to @thomasruns for initial research into this subject and @lhartwell for feedback on wording, spelling and grammar with the additional documentation (just the docs addition, not this PR, errors here are my own!)

### Final Comments

Thank you in advance for your consideration. I realize with every feature add, that it must be done carefully and diligently with attention paid to how it will need to be maintained. I hope that by putting this together, it can meet those stringent standards of a feature worth adding.