### PR TITLE
Authentication Based Multi-Tenancy Documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",
-        "mockery/mockery": "^1.4",
+        "mockery/mockery": "^1.5",
         "orchestra/testbench": "^6.23|^7.0",
         "phpunit/phpunit": "^9.4",
         "spatie/valuestore": "^1.2",

--- a/docs/advanced-usage/authentication-aware-tenant-identification.md
+++ b/docs/advanced-usage/authentication-aware-tenant-identification.md
@@ -1,0 +1,149 @@
+---
+title: Authentication aware tenant identification
+weight: 10
+---
+
+Some projects will have their tenant based on a user attribute.
+
+On every request determining a tenant will happen at the very beginning of a request, even before routes and authentication are done. To utilize the tenantFinder after authentication, create and prioritize a middleware to determine tenant.
+
+## Base Installation
+
+Ensure the steps in [base installation](/docs/laravel-multitenancy/v2/installation/base-installation) have been completed with the fact that only some routes will be tenant aware in mind.
+
+## Create relation between users and tenant
+
+To identify a tenant from the User model, create a relation between the two.
+
+Create relation migration.
+
+```bash
+php artisan make:migration add_tenant_column_to_users
+```
+
+In the new migration file, create a relation between users and tenants.
+
+```php
+use Spatie\Multitenancy\Models\Tenant;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignIdFor(Tenant::class)->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('tenant_id');
+        });
+    }
+};
+```
+
+In users model, create eloquent relation indicating users belong to tenant.
+
+```php
+// in `app\Models\Users.php`
+use Spatie\Multitenancy\Models\Tenant;
+
+// ...
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+// ...
+```
+
+## Create custom tenant finder
+
+Create a tenant finder that returns the current tenant. Ensure it returns early if the user is not logged in.
+
+```php
+\\ In `app/Http/AuthenticatedTenantFinder.php`
+namespace App\Http;
+
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Http\Request;
+use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\TenantFinder\TenantFinder as MultitenancyTenantFinder;
+
+class AuthenticatedTenantFinder extends MultitenancyTenantFinder
+{
+    use UsesTenantModel;
+
+    public function __construct(
+        protected Guard $authGuard
+    ) {}
+
+    public function findForRequest(Request $request): ?Tenant
+    {
+        $tenantId = $this->authGuard->user()?->tenant_id;
+        if (is_null($tenantId))
+            return null; // No tenant, no need to search db.
+        $tenant = $this->getTenantModel()->find($tenantId);
+        return $tenant;
+    }
+}
+```
+
+Configure tenant finder in multitenancy configuration.
+
+```php
+// In `app/Http/TenantFinder.php`
+
+// ...
+    'tenant_finder' => \App\Http\AuthenticatedTenantFinder::class,
+// ...
+
+```
+
+## Create DetermineTenant middleware
+
+Create new middleware so that you can control when the determine tenant action happens.
+
+```php
+// in `app/Http/Middleware/DetermineTenant`
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Spatie\Multitenancy\Multitenancy;
+
+class DetermineTenant
+{
+    public function __construct(
+        protected Multitenancy $multitenancy
+    ) {}
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $this->multitenancy->determineCurrentTenant($request);
+        return $next($request);
+    }
+}
+```
+
+## Add the middleware to tenant group
+
+Update tenant middleware group to include determination of tenant.
+
+```php
+// in `app\Http\Kernel.php`
+
+protected $middlewareGroups = [
+    // ...
+    'tenant' => [
+        \App\Http\Middleware\DetermineTenant::class,
+        \Spatie\Multitenancy\Http\Middleware\NeedsTenant::class
+    ]
+];
+```
+
+Ensure the tenant is determined prior to declaring need for tenant. Remove the `EnsureValidTenantSession` middleware, as your sessions are not separated by tenant, instead being dependent upon laravel authentication.

--- a/src/Multitenancy.php
+++ b/src/Multitenancy.php
@@ -33,7 +33,7 @@ class Multitenancy
         Tenant::forgetCurrent();
     }
 
-    protected function determineCurrentTenant(): void
+    public function determineCurrentTenant(): void
     {
         if (! $this->app['config']->get('multitenancy.tenant_finder')) {
             return;

--- a/src/Multitenancy.php
+++ b/src/Multitenancy.php
@@ -3,6 +3,7 @@
 namespace Spatie\Multitenancy;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Http\Request;
 use Spatie\Multitenancy\Actions\MakeQueueTenantAwareAction;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
@@ -33,7 +34,7 @@ class Multitenancy
         Tenant::forgetCurrent();
     }
 
-    public function determineCurrentTenant(): void
+    public function determineCurrentTenant(?Request $request = null): void
     {
         if (! $this->app['config']->get('multitenancy.tenant_finder')) {
             return;
@@ -42,7 +43,7 @@ class Multitenancy
         /** @var \Spatie\Multitenancy\TenantFinder\TenantFinder $tenantFinder */
         $tenantFinder = $this->app[TenantFinder::class];
 
-        $tenant = $tenantFinder->findForRequest($this->app['request']);
+        $tenant = $tenantFinder->findForRequest($request ?? $this->app['request']);
 
         $tenant?->makeCurrent();
     }

--- a/tests/Feature/DetermineCurrentTenantTest.php
+++ b/tests/Feature/DetermineCurrentTenantTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Mockery\MockInterface;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Multitenancy;
+use Spatie\Multitenancy\TenantFinder\TenantFinder;
+use Spatie\Multitenancy\Tests\TestCase;
+
+class DetermineCurrentTenantTest extends TestCase
+{
+    protected MockInterface $tenantFinderMock;
+    protected MockInterface $tenantMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Set dumy configuration for tenantFinder.
+        config()->set('multitenancy.tenant_finder', TenantFinder::class);
+
+        // Setup mock tenant
+        $this->tenantMock = $this->mock(Tenant::class);
+        $this->tenantMock->shouldReceive('makeCurrent')->andReturnSelf();
+
+        // Setup a mock to check usage of TenantFinder.
+        $this->tenantFinderMock = $this->mock(TenantFinder::class);
+        $this->tenantFinderMock->shouldReceive('findForRequest')
+            ->withArgs([\Mockery::type(Request::class)])
+            ->andReturns($this->tenantMock);
+    }
+
+    /** @test */
+    public function it_will_find_tenant_from_middleware_request()
+    {
+        $request = $this->mock(Request::class);
+
+        // Run determineCurrentTenant with our request.
+        app(Multitenancy::class)->determineCurrentTenant($request);
+
+        // Ensure it hit findForRequest with the request we provided.
+        $this->tenantFinderMock->shouldHaveReceived('findForRequest')->with($request);
+    }
+
+    /** @test */
+    public function it_makes_tenant_found_from_middleware_current()
+    {
+        $request = $this->mock(Request::class);
+
+        // Run determineCurrentTenant with our request.
+        app(Multitenancy::class)->determineCurrentTenant($request);
+
+        // Ensure it made tenant current.
+        $this->tenantMock->shouldHaveReceived('makeCurrent');
+    }
+}


### PR DESCRIPTION
This PR changes the core `Multitenancy` service in ways required for authentication based multi-tenancy, as well as adding documentation on how to setup authentication aware multi-tenancy.

What changed?
In order to determineTenancy at a time other than application boot, I changed `Multitenancy::determineTenant` to public, and add the ability to allow the request to be passed in directly when available.

Why change `Multitenancy` service?
In previous PR, it was suggested that authentication aware determine tenant middleware be in documentation instead of as a class in the repository. In order to keep this class simple, and ensure it picks up future changes from this package, I wanted to reuse the determine tenant logic from where it is used by the rest of the package.

Are the changes tested?
I have added a test that ensures that the determine tenant method is public and does what is expected. Since the original service is not covered by the test suite, I did not have a good example to follow, so I tried to do my best to match other tests. I am open to feedback so that I can better match the project conventions.

Significant changes from previous PR:
- TenantFinder now uses Dependency Injection instead of Facade.
- DetermineTenant middleware uses Dependency Injection instead of Facade.
- Tests removed that covered the middleware, since it is now implemented in the documentation.

Dependency Change
Increased the minimum version of Mockery, so that tests with mocks utilizing shouldHaveReceived could function without error.

For reference of origin of this PR, see previous PR: https://github.com/spatie/laravel-multitenancy/pull/394

Credits
Thanks to @thomasruns for initial research into this subject and @lhartwell for feedback on wording, spelling and grammar with the additional documentation (just the docs addition, not this PR, errors here are my own!)

Current Questions I'm interested in getting answers to:
- [x] Is the advanced usage the best placement for this documentation.
- [x] Suggestions as to where this could be linked to from existing documentation.
- [x] Suggestions on how I might approach testing in a way that doesn't require a bump in the dependencies to resolve the mockery issue.
- [x] Should the documentation include samples with methods to add testing of their added code, or should this be left to be an exercise of the user? I already have the tests, just need to figure out if and how to include them.
- [x] This continues to have the issue of calling tenantFinder twice for every request, so possibly adding a conditional in the config that disables the determineTenant find at boot? thoughts?