### PR TITLE
[no ci] Fix typo in config comment

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -76,7 +76,7 @@ return [
     'shared_routes_cache' => false,
 
     /*
-     * You can customize some of the behavior of this package by using our own custom action.
+     * You can customize some of the behavior of this package by using your own custom action.
      * Your custom action should always extend the default one.
      */
     'actions' => [


### PR DESCRIPTION
The comment means to say "your" but instead is missing the "y" and says "our".