### PR TITLE
Fix unmatched double quote (typo)

### DIFF
--- a/tests/Feature/Commands/TenantsArtisanCommandTest.php
+++ b/tests/Feature/Commands/TenantsArtisanCommandTest.php
@@ -30,7 +30,7 @@ it('can migrate all tenant databases', function () {
 });
 
 it('can migrate a specific tenant', function () {
-    $this->artisan('tenants:artisan migrate --tenant=' . $this->anotherTenant->id . '"')->assertExitCode(0);
+    $this->artisan('tenants:artisan migrate --tenant="' . $this->anotherTenant->id . '"')->assertExitCode(0);
 
     assertTenantDatabaseDoesNotHaveTable($this->tenant, 'migrations');
     assertTenantDatabaseHasTable($this->anotherTenant, 'migrations');


### PR DESCRIPTION
The value that the `tenant` option is set to is followed by a double quote, but it does not have an opening double quote.
