### PR TITLE
Fix determineCurrentTenant Execution in Unit Tests

### DIFF
--- a/src/Multitenancy.php
+++ b/src/Multitenancy.php
@@ -69,7 +69,7 @@ class Multitenancy
 
     protected function configureRequests(): self
     {
-        if (! $this->app->runningInConsole()  || $this->app->runningUnitTests() ) {
+        if (! $this->app->runningInConsole()  || ($this->app->runningUnitTests() && $this->app['request'] !== null) ) {
             $this->determineCurrentTenant();
         }
 

--- a/src/Multitenancy.php
+++ b/src/Multitenancy.php
@@ -69,7 +69,7 @@ class Multitenancy
 
     protected function configureRequests(): self
     {
-        if (! $this->app->runningInConsole()) {
+        if (! $this->app->runningInConsole()  || $this->app->runningUnitTests() ) {
             $this->determineCurrentTenant();
         }
 


### PR DESCRIPTION
This PR addresses an issue where the determineCurrentTenant method was not being executed during unit tests, causing the Spatie\Multitenancy\Exceptions\NoCurrentTenant exception to be thrown. This issue prevented proper testing of HTTP requests in a multitenant environment.

The fix ensures that determineCurrentTenant is executed not only when the application is not running in the console but also when it is running unit tests. This allows for complete test coverage of HTTP requests that involve tenant identification.

By implementing this fix, developers can now effectively write and run unit tests that cover tenant identification through HTTP requests, ensuring that their applications are robust and reliable.

![image](https://user-images.githubusercontent.com/3660446/233340693-94a328a2-1e1c-48cf-aab3-15766399974d.png)

![image](https://user-images.githubusercontent.com/3660446/233340605-d6808902-2dc9-4fbd-9367-05ce3f354cfd.png)

