### PR TITLE
Bind or forget current tenant

### DIFF
--- a/src/Actions/MakeTenantCurrentAction.php
+++ b/src/Actions/MakeTenantCurrentAction.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Multitenancy\Actions;
 
+use Spatie\Multitenancy\Concerns\BindAsCurrentTenant;
 use Spatie\Multitenancy\Events\MadeTenantCurrentEvent;
 use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
 use Spatie\Multitenancy\Models\Tenant;
@@ -10,6 +11,8 @@ use Spatie\Multitenancy\Tasks\TasksCollection;
 
 class MakeTenantCurrentAction
 {
+    use BindAsCurrentTenant;
+
     public function __construct(
         protected TasksCollection $tasksCollection
     ) {
@@ -31,17 +34,6 @@ class MakeTenantCurrentAction
     protected function performTasksToMakeTenantCurrent(Tenant $tenant): self
     {
         $this->tasksCollection->each(fn (SwitchTenantTask $task) => $task->makeCurrent($tenant));
-
-        return $this;
-    }
-
-    protected function bindAsCurrentTenant(Tenant $tenant): self
-    {
-        $containerKey = config('multitenancy.current_tenant_container_key');
-
-        app()->forgetInstance($containerKey);
-
-        app()->instance($containerKey, $tenant);
 
         return $this;
     }

--- a/src/Concerns/BindAsCurrentTenant.php
+++ b/src/Concerns/BindAsCurrentTenant.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\Multitenancy\Concerns;
+
+use Spatie\Multitenancy\Models\Tenant;
+
+trait BindAsCurrentTenant
+{
+    protected function bindAsCurrentTenant(Tenant $tenant): self
+    {
+        $containerKey = config('multitenancy.current_tenant_container_key');
+
+        app()->forgetInstance($containerKey);
+
+        app()->instance($containerKey, $tenant);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This PR aims to address the following issues: #422, which involves clearing and binding a new tenant instance to prevent the data from becoming outdated, and #442, which was encountered while upgrading to v3.