### PR TITLE
Add method`use()` as an alias for `makeCurrent()`

### DIFF
--- a/src/Models/Tenant.php
+++ b/src/Models/Tenant.php
@@ -32,6 +32,11 @@ class Tenant extends Model
         return $this;
     }
 
+    public function use(): static
+    {
+        return $this->makeCurrent();
+    }
+
     public function forget(): static
     {
         $this


### PR DESCRIPTION
This PR just adds an alias for the `makeCurrent()` method, as some syntactic sugar.

```php
// To make a tenant the current one, we can currently do this;
$tenant->makeCurrent();

// This PR also let's us do this;
$tenant->use();
```

The philosophy is inline with the current simple, terse, one word `forget()` method.

```php
$tenant->forget();
```
Inspiration: https://youtu.be/592EgykFOz4?t=543 @themsaid
