### PR TITLE
Show tenant info for all `TenantAware` commands

### DIFF
--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -29,9 +29,19 @@ trait TenantAware
             return -1;
         }
 
-        return $tenantQuery
-            ->cursor()
-            ->map(fn ($tenant) => $tenant->execute(fn () => (int) $this->laravel->call([$this, 'handle'])))
-            ->sum();
+        $result = 0;
+
+        foreach ($tenantQuery->cursor() as $index => $tenant) {
+            if ($index > 0) {
+                $this->line('');
+            }
+
+            $this->info("Running command for tenant `{$tenant->name}` (ID: {$tenant->getKey()})...");
+            $this->line("---------------------------------------------------------");
+
+            $result += $tenant->execute(fn () => (int) $this->laravel->call([$this, 'handle']));
+        }
+
+        return $result;
     }
 }

--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Artisan;
 use Spatie\Multitenancy\Commands\Concerns\TenantAware;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Spatie\Multitenancy\Models\Concerns\UsesTenantModel;
-use Spatie\Multitenancy\Models\Tenant;
 
 class TenantsArtisanCommand extends Command
 {
@@ -25,12 +24,6 @@ class TenantsArtisanCommand extends Command
 
         $artisanCommand = addslashes($artisanCommand);
 
-        $tenant = Tenant::current();
-
-        $this->line('');
-        $this->info("Running command for tenant `{$tenant->name}` (id: {$tenant->getKey()})...");
-        $this->line("---------------------------------------------------------");
-
-        Artisan::call($artisanCommand, [], $this->output);
+        return Artisan::call($artisanCommand, [], $this->output);
     }
 }


### PR DESCRIPTION
This PR enables the output of the tenant info for each command that uses the `TenantAware` trait, instead of being only available for the `TenantsArtisanCommand`.