### PR TITLE
Show name of the job in the Exception

### DIFF
--- a/src/Exceptions/CurrentTenantCouldNotBeDeterminedInTenantAwareJob.php
+++ b/src/Exceptions/CurrentTenantCouldNotBeDeterminedInTenantAwareJob.php
@@ -9,11 +9,11 @@ class CurrentTenantCouldNotBeDeterminedInTenantAwareJob extends Exception
 {
     public static function noIdSet(JobProcessing $event)
     {
-        return new static("The current tenant could not be determined in a job named `" . $event->job->getName() . "`. No `tenantId` was set in the payload.");
+        return new static("The current tenant could not be determined in a job named `" . $event->job->resolveName() . "`. No `tenantId` was set in the payload.");
     }
 
     public static function noTenantFound(JobProcessing $event): static
     {
-        return new static("The current tenant could not be determined in a job named `" . $event->job->getName() . "`. The tenant finder could not find a tenant.");
+        return new static("The current tenant could not be determined in a job named `" . $event->job->resolveName() . "`. The tenant finder could not find a tenant.");
     }
 }


### PR DESCRIPTION
This PR improves the clarity of the exception messages by specifying where the issue occurs.

Before:
```
local.ERROR: The current tenant could not be determined in a job named `Illuminate\Queue\CallQueuedHandler@call`. No `tenantId` was set in the payload. {"exception":"[object] (Spatie\\Multitenancy\\Exceptions\\CurrentTenantCouldNotBeDeterminedInTenantAwareJob(code: 0): The current tenant could not be determined in a job named `Illuminate\\Queue\\CallQueuedHandler@call`. No `tenantId` was set in the payload. at /vendor/spatie/laravel-multitenancy/src/Exceptions/CurrentTenantCouldNotBeDeterminedInTenantAwareJob.php:12)
```

After:
```
local.ERROR: The current tenant could not be determined in a job named `Spatie\Health\Jobs\HealthQueueJob`. No `tenantId` was set in the payload. {"exception":"[object] (Spatie\\Multitenancy\\Exceptions\\CurrentTenantCouldNotBeDeterminedInTenantAwareJob(code: 0): The current tenant could not be determined in a job named `Spatie\\Health\\Jobs\\HealthQueueJob`. No `tenantId` was set in the payload. at /vendor/spatie/laravel-multitenancy/src/Exceptions/CurrentTenantCouldNotBeDeterminedInTenantAwareJob.php:12)
```