### PR TITLE
Fix sqlite driver database lock

### DIFF
--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -28,8 +28,10 @@ trait TenantAware
             return -1;
         }
 
+        $tenantDriver = config('database.connections.'.app(IsTenant::class)->getConnectionName().'.driver');
+
         return $tenantQuery
-            ->cursor()
+            ->when($tenantDriver === 'sqlite', fn ($q) => $q->get(), fn ($q) => $q->cursor())
             ->map(fn (IsTenant $tenant) => $tenant->execute(fn () => (int) $this->laravel->call([$this, 'handle'])))
             ->sum();
     }

--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Multitenancy\Commands\Concerns;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Spatie\Multitenancy\Contracts\IsTenant;
@@ -31,7 +32,7 @@ trait TenantAware
         $tenantDriver = config('database.connections.'.app(IsTenant::class)->getConnectionName().'.driver');
 
         return $tenantQuery
-            ->when($tenantDriver === 'sqlite', fn ($q) => $q->get(), fn ($q) => $q->cursor())
+            ->when($tenantDriver === 'sqlite', fn (Builder $query) => $query->get(), fn (Builder $query) => $query->cursor())
             ->map(fn (IsTenant $tenant) => $tenant->execute(fn () => (int) $this->laravel->call([$this, 'handle'])))
             ->sum();
     }


### PR DESCRIPTION
This pull request fixes an issue with the `tenants:artisan` command when using the SQLite driver. Previously, running commands like `tinker` would lock the database file because the cursor remained open, preventing the connection from closing until all tenants were processed.

The fix checks if the `IsTenant`-defined model is using a connection with the SQLite driver. If so, it retrieves the tenants with a `get()` instead of using a `cursor()`, ensuring the connection is closed promptly and the database file is not locked.