### PR TITLE
[Bugfix]: Jobs with `ShouldBeEncrypted` need to be decrypted

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -49,10 +49,10 @@ class MakeQueueTenantAwareAction
     protected function isTenantAware(JobProcessing|JobRetryRequested $event): bool
     {
         $payload = $this->getEventPayload($event);
-        
+
         $serializedCommand = $payload['data']['command'];
 
-        if (!str_starts_with($serializedCommand, 'O:')) {
+        if (! str_starts_with($serializedCommand, 'O:')) {
             $serializedCommand = app(Encrypter::class)->decrypt($serializedCommand);
         }
 

--- a/tests/Feature/TenantAwareJobs/TestClasses/EncryptedTenantAware.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/EncryptedTenantAware.php
@@ -3,7 +3,6 @@
 namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
 
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Spatie\Multitenancy\Jobs\TenantAware;
 
 class EncryptedTenantAware extends TestJob implements TenantAware, ShouldBeEncrypted

--- a/tests/Feature/TenantAwareJobs/TestClasses/EncryptedTenantAware.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/EncryptedTenantAware.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
+
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Spatie\Multitenancy\Jobs\TenantAware;
+
+class EncryptedTenantAware extends TestJob implements TenantAware, ShouldBeEncrypted
+{
+}


### PR DESCRIPTION
Hi, 

Minor fix for jobs with the interface `Illuminate\Contracts\Queue\ShouldBeEncrypted`, which fixes my issue when running https://github.com/nWidart/laravel-modules and the same issue in https://github.com/spatie/laravel-multitenancy/issues/575.

**Error:**
`unserialize() error at offset 0 of XX bytes`

**Background:**
The interface will encrypt the `$payload['data']['command']` value and is therefore required to be decrypted before we try to `unserialize` it. Below is the Laravel code that encrypts the value.
```php
$command = $this->jobShouldBeEncrypted($job) && $this->container->bound(Encrypter::class)
    ? $this->container[Encrypter::class]->encrypt(serialize(clone $job))
    : serialize(clone $job);
``` 
https://github.com/laravel/framework/blob/12.x/src/Illuminate/Queue/Queue.php#L170

The solution to check if it's encrypted is taken from this Laravel implementation:
https://github.com/laravel/framework/blob/12.x/src/Illuminate/Queue/Console/RetryCommand.php#L183 

As mentioned in the issue, this wasn't an issue in v3, since `bindOrForgetCurrentTenant` in the event listeners `app('events')->listen(JobProcessing::class, ...)` never used the `$payload['data']['command']`. It was only used in the queue binding `app('queue')->createPayloadUsing(...)`.
https://github.com/spatie/laravel-multitenancy/blob/v3/src/Actions/MakeQueueTenantAwareAction.php