### PR TITLE
Add types to TenantCollection

### DIFF
--- a/src/TenantCollection.php
+++ b/src/TenantCollection.php
@@ -5,6 +5,11 @@ namespace Spatie\Multitenancy;
 use Illuminate\Database\Eloquent\Collection;
 use Spatie\Multitenancy\Contracts\IsTenant;
 
+/**
+ * @template TKey of array-key
+ * @template TValue of IsTenant
+ * @extends Collection<TKey, TValue>
+ */
 class TenantCollection extends Collection
 {
     public function eachCurrent(callable $callable): static


### PR DESCRIPTION
Adds the generic types to the `TenantCollection`. This can be used in projects that use PHPStan with Type Checking enabled.