### PR TITLE
TenantAware `before` Method

### DIFF
--- a/docs/advanced-usage/making-artisan-commands-tenant-aware.md
+++ b/docs/advanced-usage/making-artisan-commands-tenant-aware.md
@@ -65,3 +65,12 @@ If the command only needs to run for a specific tenant, you can pass its `id` to
 ```bash
 php artisan tenants:artisan "migrate --seed" --tenant=123
 ```
+
+### Using `before`
+When using `TenantAware`, the same command instance is executed for each tenant.
+This means that instance properties will retain their values between tenant executions unless explicitly reset.
+
+As a fluent solution, you can implement the `before` method, which is called before each tenant execution of the command.
+
+This is useful for resetting variables or fluently encapsulating logic before each tenant execution.
+

--- a/docs/advanced-usage/making-artisan-commands-tenant-aware.md
+++ b/docs/advanced-usage/making-artisan-commands-tenant-aware.md
@@ -67,10 +67,33 @@ php artisan tenants:artisan "migrate --seed" --tenant=123
 ```
 
 ### Using `before`
-When using `TenantAware`, the same command instance is executed for each tenant.
-This means that instance properties will retain their values between tenant executions unless explicitly reset.
 
-As a fluent solution, you can implement the `before` method, which is called before each tenant execution of the command.
+The `before` method offers a fluent way to execute code before each tenant execution. 
+This is particularly helpful when you need to reset variables or fluently encapsulate logic before each tenant execution 
+as state is persisted between tenant executions.
 
-This is useful for resetting variables or fluently encapsulating logic before each tenant execution.
+```php
+use Illuminate\Console\Command;
+use Spatie\Multitenancy\Commands\Concerns\TenantAware;
 
+class YourFavoriteCommand extends Command
+{
+use TenantAware;
+
+    protected $signature = 'your-favorite-command {--tenant=*}';
+
+    protected int $counter = 0;
+
+    public function handle()
+    {
+        $this->incrementCounter();
+
+        return $this->line('Counter: '. $this->counter);
+    }
+
+    public function before(): void
+    {
+        $this->counter = 0;
+    }
+}
+```

--- a/src/Commands/Concerns/TenantAware.php
+++ b/src/Commands/Concerns/TenantAware.php
@@ -30,7 +30,13 @@ trait TenantAware
 
         return $tenantQuery
             ->cursor()
-            ->map(fn (IsTenant $tenant) => $tenant->execute(fn () => (int) $this->laravel->call([$this, 'handle'])))
+            ->map(fn (IsTenant $tenant) => $tenant->execute(function () {
+                $this->before();
+
+                return (int) $this->laravel->call([$this, 'handle']);
+            }))
             ->sum();
     }
+
+    public function before(): void {}
 }

--- a/tests/Feature/Commands/TenantAwareCommandTest.php
+++ b/tests/Feature/Commands/TenantAwareCommandTest.php
@@ -23,3 +23,11 @@ it('works with no tenant parameters', function () {
         ->expectsOutput('Tenant ID is ' . $this->tenant->id)
         ->expectsOutput('Tenant ID is ' . $this->anotherTenant->id);
 });
+
+it('before is called', function () {
+    $this
+        ->artisan('tenant:before')
+        ->assertExitCode(0)
+        ->expectsOutput('Tenant count is: ' . 1)
+        ->expectsOutput('Tenant count is: ' . 1);
+});

--- a/tests/Feature/Commands/TestClasses/TenantBeforeCommand.php
+++ b/tests/Feature/Commands/TestClasses/TenantBeforeCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\Commands\TestClasses;
+
+use Illuminate\Console\Command;
+use Spatie\Multitenancy\Commands\Concerns\TenantAware;
+use Spatie\Multitenancy\Models\Tenant;
+
+class TenantBeforeCommand extends Command
+{
+    use TenantAware;
+
+    protected $signature = 'tenant:before {--tenant=*}';
+
+    protected $description = 'Execute before for tenant(s)';
+
+    protected int $counter = 0;
+
+    public function handle()
+    {
+        $this->counter++;
+
+        $this->line('Tenant count is: '. $this->counter);
+    }
+
+    public function before(): void
+    {
+        $this->counter = 0;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\MultitenancyServiceProvider;
+use Spatie\Multitenancy\Tests\Feature\Commands\TestClasses\TenantBeforeCommand;
 use Spatie\Multitenancy\Tests\Feature\Commands\TestClasses\TenantNoopCommand;
 
 abstract class TestCase extends Orchestra
@@ -44,6 +45,7 @@ abstract class TestCase extends Orchestra
         Artisan::starting(function ($artisan) {
             $artisan->resolveCommands([
                 TenantNoopCommand::class,
+                TenantBeforeCommand::class,
             ]);
         });
 


### PR DESCRIPTION
When using the `TenantAware` trait, I encountered unexpected behaviour where a global variable retained its value between tenant executions. My command was keeping count of a specific value (starting at 0), but when the next tenant command executed, it was not 0 but the count from the previous execution.

I came up with this solution to implement a `before` method, which developers can hook into to fluently define any logic that should be run before each tenant execution. I'm on the fence with this as its probably not necessary when most of the time its easy enough to add this at the start of each command, but wouldn't it be nice to have a method that automatically applies before each execution without adding it to the start of the command?

Happy to hash this out or just update the documentation to highlight this behaviour.