### PR TITLE
feat: Add configuration option to specify `TenantAware` and `NotTenantAware` interfaces

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -1,8 +1,10 @@
 <?php
 
+use Spatie\Multitenancy\Jobs\TenantAware;
 use Illuminate\Broadcasting\BroadcastEvent;
 use Illuminate\Events\CallQueuedListener;
 use Illuminate\Mail\SendQueuedMailable;
+use Spatie\Multitenancy\Jobs\NotTenantAware;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Queue\CallQueuedClosure;
 use Spatie\Multitenancy\Actions\ForgetCurrentTenantAction;
@@ -106,6 +108,16 @@ return [
         CallQueuedListener::class => 'class',
         BroadcastEvent::class => 'event',
     ],
+
+    /*
+    * Interface that once implemented, will make the job tenant aware
+    */
+    `tenant_aware_interface` => TenantAware::class,
+
+    /*
+     * Interface that once implemented, will make the job not tenant aware
+     */
+    `not_tenant_aware_interface` => NotTenantAware::class,
 
     /*
      * Jobs tenant aware even if these don't implement the TenantAware interface.

--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -76,11 +76,11 @@ class MakeQueueTenantAwareAction
 
         $reflection = new ReflectionClass($job);
 
-        if ($reflection->implementsInterface(TenantAware::class)) {
+        if ($reflection->implementsInterface(config('multitenancy.tenant_aware_interface', TenantAware::class))) {
             return true;
         }
 
-        if ($reflection->implementsInterface(NotTenantAware::class)) {
+        if ($reflection->implementsInterface(config('multitenancy.not_tenant_aware_interface', NotTenantAware::class))) {
             return false;
         }
 

--- a/tests/Feature/TenantAwareJobs/TenantAwareJobsByConfigTest.php
+++ b/tests/Feature/TenantAwareJobs/TenantAwareJobsByConfigTest.php
@@ -4,6 +4,10 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Spatie\Multitenancy\Models\Tenant;
 use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TestJob;
 use Spatie\Valuestore\Valuestore;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\CustomTenantAware;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\CustomNotTenantAware;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TestJobCustomTenantAware;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TestJobCustomNotTenantAware;
 
 beforeEach(function () {
     config()->set('multitenancy.queues_are_tenant_aware_by_default', false);
@@ -12,6 +16,17 @@ beforeEach(function () {
 
     $this->tenant = Tenant::factory()->create();
     $this->valuestore = Valuestore::make(tempFile('tenantAware.json'))->flush();
+});
+
+it('succeeds with jobs with a custom tenant aware interface', function () {
+    config()->set('multitenancy.tenant_aware_interface', CustomTenantAware::class);
+
+    $this->tenant->makeCurrent();
+
+    app(Dispatcher::class)->dispatch(new TestJobCustomTenantAware($this->valuestore));
+
+    expect($this->valuestore->has('tenantIdInContext'))->toBeTrue()
+        ->and($this->valuestore->get('tenantIdInContext'))->not->toBeNull();
 });
 
 it('succeeds with jobs in tenant aware jobs list', function () {
@@ -31,6 +46,19 @@ it('fails with jobs in not tenant aware jobs list', function () {
     $this->tenant->makeCurrent();
 
     app(Dispatcher::class)->dispatch(new TestJob($this->valuestore));
+
+    expect($this->valuestore->get('tenantId'))->toBeNull()
+        ->and($this->valuestore->get('tenantName'))->toBeNull()
+        ->and($this->valuestore->has('tenantIdInContext'))->toBeTrue();
+});
+
+
+it('fails with jobs implementing custom not tenant aware jobs', function () {
+    config()->set('multitenancy.not_tenant_aware_interface', CustomNotTenantAware::class);
+
+    $this->tenant->makeCurrent();
+
+    app(Dispatcher::class)->dispatch(new TestJobCustomNotTenantAware($this->valuestore));
 
     expect($this->valuestore->get('tenantId'))->toBeNull()
         ->and($this->valuestore->get('tenantName'))->toBeNull()

--- a/tests/Feature/TenantAwareJobs/TestClasses/CustomNotTenantAware.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/CustomNotTenantAware.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
+
+interface CustomNotTenantAware
+{
+
+}

--- a/tests/Feature/TenantAwareJobs/TestClasses/CustomTenantAware.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/CustomTenantAware.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
+
+interface CustomTenantAware
+{
+
+}

--- a/tests/Feature/TenantAwareJobs/TestClasses/TestJobCustomNotTenantAware.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/TestJobCustomNotTenantAware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Context;
+use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Valuestore\Valuestore;
+
+class TestJobCustomNotTenantAware implements ShouldQueue, CustomNotTenantAware
+{
+    use InteractsWithQueue;
+    use Dispatchable;
+    use UsesMultitenancyConfig;
+
+    public Valuestore $valuestore;
+
+    public function __construct(Valuestore $valuestore)
+    {
+        $this->valuestore = $valuestore;
+    }
+
+    public function handle()
+    {
+        $this->valuestore->put('tenantIdInContext', Context::get($this->currentTenantContextKey()));
+        $this->valuestore->put('tenantId', Tenant::current()?->id);
+        $this->valuestore->put('tenantName', Tenant::current()?->name);
+    }
+}

--- a/tests/Feature/TenantAwareJobs/TestClasses/TestJobCustomTenantAware.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/TestJobCustomTenantAware.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Context;
+use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Valuestore\Valuestore;
+
+class TestJobCustomTenantAware implements ShouldQueue, CustomTenantAware
+{
+    use InteractsWithQueue;
+    use Dispatchable;
+    use UsesMultitenancyConfig;
+
+    public Valuestore $valuestore;
+
+    public function __construct(Valuestore $valuestore)
+    {
+        $this->valuestore = $valuestore;
+    }
+
+    public function handle()
+    {
+        $this->valuestore->put('tenantIdInContext', Context::get($this->currentTenantContextKey()));
+        $this->valuestore->put('tenantId', Tenant::current()?->id);
+        $this->valuestore->put('tenantName', Tenant::current()?->name);
+    }
+}


### PR DESCRIPTION
The goal of this PR is to add 2 new keys in the config file that'll allow the user to specify the interface that determines if given job is TenantAware.

The usecase for this is as follows:

1. I'm building a "foundation" package to be used by multiple consumers that themselves use the spatie/laravel-multitenancy
2. I do not want the "foundation" package to have this package installed as dependency
3. Without going into much detail, the "foundation" package provides abstract, basic stuff like BaseJob, or SchedulerJob, where I want to specify some tenancy behavior, those classes will be extended on the app-level, but I don't want consumers to always add `implements NotTenantAware`

Alternative solutions:
1. Without those interfaces being configurable, I need to override `MakeQueueTenantAwareAction` (or at least function on it `isTenantAware`), which is completely acceptable solution if you do not believe that this configuration option benefits the broader public
2. I can modify this so that the `tenant_aware_jobs` and `not_tenant_aware_jobs` would instead also validate all the parents of given job class, which you could argue makes it easier to specify a couple of different inheritance exclusions

Thanks for this beautiful package :) 