### PR TITLE
Fix syntax for tenant aware interface config

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -112,12 +112,12 @@ return [
     /*
     * Interface that once implemented, will make the job tenant aware
     */
-    `tenant_aware_interface` => TenantAware::class,
+    'tenant_aware_interface' => TenantAware::class,
 
     /*
      * Interface that once implemented, will make the job not tenant aware
      */
-    `not_tenant_aware_interface` => NotTenantAware::class,
+    'not_tenant_aware_interface' => NotTenantAware::class,
 
     /*
      * Jobs tenant aware even if these don't implement the TenantAware interface.


### PR DESCRIPTION
The config options are attempting to be run as shell commands, as backticks are being used instead of quotes. Introduced #607.

https://www.php.net/manual/en/language.operators.execution.php

@masterix21 this is quite a major issue introduced in today's release.