### PR TITLE
Automatically set database.default to tenant connection in SwitchTenantDatabaseTaskUpdate SwitchTenantDatabaseTask.php

### DIFF
--- a/src/Tasks/SwitchTenantDatabaseTask.php
+++ b/src/Tasks/SwitchTenantDatabaseTask.php
@@ -36,6 +36,7 @@ class SwitchTenantDatabaseTask implements SwitchTenantTask
 
         config([
             "database.connections.{$tenantConnectionName}.database" => $databaseName,
+            "database.default" => $tenantConnectionName,
         ]);
 
         app('db')->extend($tenantConnectionName, function ($config, $name) use ($databaseName) {


### PR DESCRIPTION
Currently, when switching tenants using SwitchTenantDatabaseTask, the tenant connection is configured
and purged, but the Laravel default database connection (`database.default`) remains pointing to 
the landlord connection. This means that any query or model that doesn't explicitly specify the tenant 
connection will continue to run on the landlord database.

This PR updates the setTenantConnectionDatabaseName() method to also set the default connection 
to the tenant connection when switching tenants. This ensures that:

- All queries and Eloquent models use the correct tenant database by default.
- The landlord connection is still available for models that explicitly specify it.
- The change does not affect ForgetCurrentTenantAction, which will reset the default connection 
  back to the landlord when the tenant is forgotten.

Example:

    config([
        'database.connections.tenant.database' => $databaseName,
        'database.default' => 'tenant',  // Automatically switch default
    ]);

This makes multi-tenant setups more intuitive and prevents accidental queries to the landlord database.
