### PR TITLE
Updated Docs Spatie Laravel Multitenancy to Laravel 12–Compatible Version

### DIFF
--- a/docs/installation/base-installation.md
+++ b/docs/installation/base-installation.md
@@ -6,7 +6,7 @@ weight: 1
 This package can be installed via composer:
 
 ```bash
-composer require "spatie/laravel-multitenancy:^4.0"
+composer require spatie/laravel-multitenancy
 ```
 
 ### Publishing the config file


### PR DESCRIPTION
Laravel 12 introduces compatibility constraints that prevent the project from installing spatie/laravel-multitenancy:^4.0. The version constraint fails during dependency resolution and is no longer suitable for the current framework version.

This pull request updates the dependency installation to use the latest compatible release of spatie/laravel-multitenancy by removing the explicit ^4.0 constraint:

Replaces composer require spatie/laravel-multitenancy:^4.0

With composer require spatie/laravel-multitenancy

This change ensures:

Successful installation on Laravel 12

Alignment with the most recent, framework-compatible package version

Reduced maintenance overhead caused by outdated version constraints

No functional changes were introduced beyond dependency compatibility.