### PR TITLE
Fix tenant context not being restored when exception occurs in execute()

### DIFF
--- a/src/Models/Concerns/ImplementsTenant.php
+++ b/src/Models/Concerns/ImplementsTenant.php
@@ -81,11 +81,13 @@ trait ImplementsTenant
 
         $this->makeCurrent();
 
-        return tap($callable($this), static function () use ($originalCurrentTenant) {
+        try {
+            return $callable($this);
+        }finally {
             $originalCurrentTenant
                 ? $originalCurrentTenant->makeCurrent()
                 : static::forgetCurrent();
-        });
+        }
     }
 
     public function callback(callable $callable): \Closure


### PR DESCRIPTION
## Description                                                                                                                                                                          
  Fixes a bug where the tenant context is not properly restored if an exception is thrown inside the callable passed to `Tenant::execute()`.                                              
                                                                                                                                                                                          
  ## Problem                                                                                                                                                                              
  The current implementation uses `tap()` to restore the tenant context:                                                                                                                  
  ```php                                                                                                                                                                                  
  return tap($callable($this), static function () use ($originalCurrentTenant) {                                                                                                          
      // restore tenant                                                                                                                                                                   
  });
```                                                                                                                                                                                     
                                                                                                                                                                                          
tap() only executes its callback if the first argument completes successfully. If $callable($this) throws an exception, the restoration logic never runs, leaving the application in the wrong tenant context.                                                                                                                                                
                                                                                                                                                                                          
## Solution                                                                                                                                                                                
                                                                                                                                                                                          
Changed to use a try-finally block, which guarantees the tenant restoration code runs regardless of whether an exception is thrown 
  ```php             
  try {                                                                                                                                                                                   
      return $callable($this);                                                                                                                                                            
  } finally {                                                                                                                                                                             
      // restore tenant - always runs                                                                                                                                                     
  }
```