### PR TITLE
Fix #620: Handle JobRetryRequested in queue tenant awareness

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -124,13 +124,17 @@ class MakeQueueTenantAwareAction
         $tenantId = Context::get($this->currentTenantContextKey());
 
         if (! $tenantId) {
-            $event->job->delete();
+            if ($event instanceof JobProcessing) {
+                $event->job->delete();
+            }
 
             throw CurrentTenantCouldNotBeDeterminedInTenantAwareJob::noIdSet($event);
         }
 
         if (! $tenant = app(IsTenant::class)::find($tenantId)) {
-            $event->job->delete();
+            if ($event instanceof JobProcessing) {
+                $event->job->delete();
+            }
 
             throw CurrentTenantCouldNotBeDeterminedInTenantAwareJob::noTenantFound($event);
         }

--- a/src/Exceptions/CurrentTenantCouldNotBeDeterminedInTenantAwareJob.php
+++ b/src/Exceptions/CurrentTenantCouldNotBeDeterminedInTenantAwareJob.php
@@ -4,16 +4,32 @@ namespace Spatie\Multitenancy\Exceptions;
 
 use Exception;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobRetryRequested;
 
 class CurrentTenantCouldNotBeDeterminedInTenantAwareJob extends Exception
 {
-    public static function noIdSet(JobProcessing $event)
+    public static function noIdSet(JobProcessing|JobRetryRequested $event)
     {
-        return new static("The current tenant could not be determined in a job named `" . $event->job->resolveName() . "`. No `tenantId` was set in the payload.");
+        $jobName = self::resolveJobName($event);
+
+        return new static("The current tenant could not be determined in a job named `{$jobName}`. No `tenantId` was set in the payload.");
     }
 
-    public static function noTenantFound(JobProcessing $event): static
+    public static function noTenantFound(JobProcessing|JobRetryRequested $event): static
     {
-        return new static("The current tenant could not be determined in a job named `" . $event->job->resolveName() . "`. The tenant finder could not find a tenant.");
+        $jobName = self::resolveJobName($event);
+
+        return new static("The current tenant could not be determined in a job named `{$jobName}`. The tenant finder could not find a tenant.");
+    }
+
+    protected static function resolveJobName(JobProcessing|JobRetryRequested $event): string
+    {
+        if ($event instanceof JobProcessing) {
+            return $event->job->resolveName();
+        }
+
+        $payload = $event->payload();
+
+        return $payload['displayName'] ?? $payload['data']['commandName'] ?? 'unknown';
     }
 }


### PR DESCRIPTION
## Summary
- `JobRetryRequested::$job` is a `stdClass`, not an `Illuminate\Contracts\Queue\Job` instance. Calling `$event->job->delete()` in `findTenant()` throws "Call to undefined method stdClass::delete()"
- The exception class `CurrentTenantCouldNotBeDeterminedInTenantAwareJob` also type-hinted only `JobProcessing` and called `$event->job->resolveName()`, which fails for `JobRetryRequested`

## Changes
- Only call `$event->job->delete()` when the event is a `JobProcessing` instance
- Updated the exception class to accept both `JobProcessing` and `JobRetryRequested` events
- Extract job name from payload for `JobRetryRequested` events instead of calling `resolveName()`

## Testing
- All 76 local tests pass (292 assertions)

Fixes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)