### PR TITLE
Fix #617: Add default value for TasksCollection constructor parameter

### DIFF
--- a/src/Tasks/TasksCollection.php
+++ b/src/Tasks/TasksCollection.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Collection;
 
 class TasksCollection extends Collection
 {
-    public function __construct($taskClassNames)
+    public function __construct($taskClassNames = [])
     {
         $tasks = collect($taskClassNames)
             ->map(function ($taskParameters, $taskClass) {


### PR DESCRIPTION
## Summary
- `TasksCollection::__construct($taskClassNames)` had a required parameter with no default value
- When Laravel's DI container tries to resolve `TasksCollection` before the singleton binding is registered (e.g., in custom service providers or artisan commands), it throws: `Unresolvable dependency resolving [Parameter #0 [ <required> $taskClassNames ]]`

## Changes
- Added default value `[]` for the `$taskClassNames` parameter in `TasksCollection::__construct()`
- When the singleton is properly bound (normal flow), the config value is passed and the default is never used
- When resolved without the binding, it gracefully creates an empty collection

## Testing
- All 76 local tests pass (292 assertions)

Fixes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)