### PR TITLE
Add PHP 8.5 to test workflow matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3, 8.2]
         laravel: ['11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
 


### PR DESCRIPTION
This commit adds PHP 8.5 to the GitHub Actions test workflow matrix to ensure the package is tested against the latest PHP version.