### PR TITLE
Add description to TenantsArtisanCommand

### DIFF
--- a/src/Commands/TenantsArtisanCommand.php
+++ b/src/Commands/TenantsArtisanCommand.php
@@ -15,6 +15,8 @@ class TenantsArtisanCommand extends Command
 
     protected $signature = 'tenants:artisan {artisanCommand} {--tenant=*}';
 
+    protected $description = 'Run an Artisan command for selected tenants.';
+
     public function handle(): void
     {
         if (! $artisanCommand = $this->argument('artisanCommand')) {


### PR DESCRIPTION
Add a default description

Fixes: https://github.com/spatie/laravel-multitenancy/issues/632#issuecomment-4214380470

## More info

Other projects have had this issue too, for example: https://github.com/DirectoryTree/LdapRecord-Laravel/issues/689

Laravel fixed it upstream, so this only affects projects that aren't up-to-date in their point/patch releases, but it's still good to have a default IMO, see: https://github.com/laravel/framework/pull/55888