### PR TITLE
Check if current session is available

### DIFF
--- a/config/multitenancy.php
+++ b/config/multitenancy.php
@@ -79,6 +79,12 @@ return [
     'current_tenant_container_key' => 'currentTenant',
 
     /*
+    * This key will be used to store the tenant id in the session when using the
+    * `EnsureValidTenantSession` middleware.
+    */
+    'current_tenant_session_key' => 'ensure_valid_tenant_session_tenant_id',
+
+    /*
      * Set it to `true` if you like to cache the tenant(s) routes
      * in a shared file using the `SwitchRouteCacheTask`.
      */

--- a/src/Concerns/UsesMultitenancyConfig.php
+++ b/src/Concerns/UsesMultitenancyConfig.php
@@ -27,6 +27,11 @@ trait UsesMultitenancyConfig
         return config('multitenancy.current_tenant_container_key');
     }
 
+    public function currentTenantSessionKey(): string
+    {
+        return config('multitenancy.current_tenant_session_key');
+    }
+
     public function getMultitenancyActionClass(string $actionName, string $actionClass)
     {
         $configuredClass = config("multitenancy.actions.{$actionName}") ?? $actionClass;

--- a/src/Http/Middleware/EnsureValidTenantSession.php
+++ b/src/Http/Middleware/EnsureValidTenantSession.php
@@ -3,6 +3,7 @@
 namespace Spatie\Multitenancy\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Spatie\Multitenancy\Concerns\UsesMultitenancyConfig;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -10,16 +11,23 @@ class EnsureValidTenantSession
 {
     use UsesMultitenancyConfig;
 
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
-        $sessionKey = 'ensure_valid_tenant_session_tenant_id';
+        $sessionKey = $this->currentTenantSessionKey();
 
+        // If the request does not have a session, we cannot verify the tenant id in the session, so we will just pass the request through.
+        if (! $request->hasSession()) {
+            return $next($request);
+        }
+
+        // If the session does not have the tenant id, we will set it to the current tenant id and pass the request
         if (! $request->session()->has($sessionKey)) {
             $request->session()->put($sessionKey, app($this->currentTenantContainerKey())->getKey());
 
             return $next($request);
         }
 
+        // If the tenant id in the session does not match the current tenant id, we will handle the invalid tenant session
         if ($request->session()->get($sessionKey) !== app($this->currentTenantContainerKey())->getKey()) {
             return $this->handleInvalidTenantSession($request);
         }
@@ -27,7 +35,7 @@ class EnsureValidTenantSession
         return $next($request);
     }
 
-    protected function handleInvalidTenantSession($request)
+    protected function handleInvalidTenantSession(Request $request)
     {
         abort(Response::HTTP_UNAUTHORIZED);
     }


### PR DESCRIPTION
Sometimes you use multitenancy on API-routes. These can have a session (e.g. with sanctum), and sometimes don't (depending on the route as well). Using the middleware on api routes, does offer some protection layer.

On Fortify they https://github.com/laravel/fortify/blob/fc66a38872a0e304748336d2975f37672c8fca9c/src/Http/Controllers/AuthenticatedSessionController.php#L104 check if a session exists. I think this can be the same for this package, but use an early return instead.

I also added the key as config option. Would that be a breaking change? Would you want a fallback key? The reason is that it allows the user to configure this key, like with other keys as well.

Let me know what you think. :)