### PR TITLE
Resolve tenant from payload context when retrying jobs

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -121,7 +121,7 @@ class MakeQueueTenantAwareAction
 
     protected function findTenant(JobProcessing|JobRetryRequested $event): IsTenant
     {
-        $tenantId = Context::get($this->currentTenantContextKey());
+        $tenantId = $this->resolveTenantId($event);
 
         if (! $tenantId) {
             if ($event instanceof JobProcessing) {
@@ -140,6 +140,37 @@ class MakeQueueTenantAwareAction
         }
 
         return $tenant;
+    }
+
+    protected function resolveTenantId(JobProcessing|JobRetryRequested $event): mixed
+    {
+        if ($event instanceof JobRetryRequested) {
+            return $this->tenantIdFromPayloadContext($event);
+        }
+
+        return Context::get($this->currentTenantContextKey());
+    }
+
+    /**
+     * When a job is retried through `queue:retry`, Laravel has not yet hydrated
+     * the stored context onto the `Context` facade, so we read the tenant id
+     * straight from the payload's serialized context instead.
+     */
+    protected function tenantIdFromPayloadContext(JobRetryRequested $event): mixed
+    {
+        $contextData = $this->getEventPayload($event)['illuminate:log:context']['data'] ?? [];
+
+        $serializedTenantId = $contextData[$this->currentTenantContextKey()] ?? null;
+
+        if ($serializedTenantId === null) {
+            return null;
+        }
+
+        try {
+            return unserialize($serializedTenantId);
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     protected function bindOrForgetCurrentTenant(JobProcessing|JobRetryRequested $event): void

--- a/tests/Feature/TenantAwareJobs/TenantAwareJobRetryTest.php
+++ b/tests/Feature/TenantAwareJobs/TenantAwareJobRetryTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\FailingTenantAwareTestJob;
+use Spatie\Valuestore\Valuestore;
+
+beforeEach(function () {
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+
+    config()->set('queue.failed', [
+        'driver' => 'database-uuids',
+        'database' => 'landlord',
+        'table' => 'failed_jobs',
+    ]);
+
+    Schema::connection('landlord')->dropIfExists('failed_jobs');
+
+    Schema::connection('landlord')->create('failed_jobs', function (Blueprint $table) {
+        $table->id();
+        $table->string('uuid')->unique();
+        $table->text('connection');
+        $table->text('queue');
+        $table->longText('payload');
+        $table->longText('exception');
+        $table->timestamp('failed_at')->useCurrent();
+    });
+
+    $this->tenant = Tenant::factory()->create();
+
+    $this->valuestore = Valuestore::make(tempFile('tenantAware.json'))->flush();
+});
+
+it('can determine the tenant when retrying a failed tenant aware job', function () {
+    $this->tenant->makeCurrent();
+
+    dispatch(new FailingTenantAwareTestJob($this->valuestore));
+
+    Tenant::forgetCurrent();
+
+    $this->artisan('queue:work --once');
+
+    expect(DB::connection('landlord')->table('failed_jobs')->count())->toBe(1);
+
+    $this->valuestore->put('shouldFail', false);
+
+    Tenant::forgetCurrent();
+    Context::flush();
+
+    $this->artisan('queue:retry all')->assertExitCode(0);
+
+    $this->artisan('queue:work --once')->assertExitCode(0);
+
+    expect($this->valuestore->get('tenantId'))->toEqual($this->tenant->id);
+});
+
+it('restores the right tenant when retrying failed jobs of different tenants', function () {
+    $otherTenant = Tenant::factory()->create();
+
+    $otherValuestore = Valuestore::make(tempFile('otherTenantAware.json'))->flush();
+
+    $this->tenant->makeCurrent();
+    dispatch(new FailingTenantAwareTestJob($this->valuestore));
+
+    $otherTenant->makeCurrent();
+    dispatch(new FailingTenantAwareTestJob($otherValuestore));
+
+    Tenant::forgetCurrent();
+
+    $this->artisan('queue:work --once');
+    $this->artisan('queue:work --once');
+
+    expect(DB::connection('landlord')->table('failed_jobs')->count())->toBe(2);
+
+    $this->valuestore->put('shouldFail', false);
+    $otherValuestore->put('shouldFail', false);
+
+    Tenant::forgetCurrent();
+    Context::flush();
+
+    $this->artisan('queue:retry all')->assertExitCode(0);
+
+    $this->artisan('queue:work --once');
+    $this->artisan('queue:work --once');
+
+    expect($this->valuestore->get('tenantId'))->toEqual($this->tenant->id)
+        ->and($otherValuestore->get('tenantId'))->toEqual($otherTenant->id);
+});

--- a/tests/Feature/TenantAwareJobs/TestClasses/FailingTenantAwareTestJob.php
+++ b/tests/Feature/TenantAwareJobs/TestClasses/FailingTenantAwareTestJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses;
+
+use Exception;
+use Spatie\Multitenancy\Jobs\TenantAware;
+
+class FailingTenantAwareTestJob extends TestJob implements TenantAware
+{
+    public int $tries = 1;
+
+    public function handle()
+    {
+        if ($this->valuestore->get('shouldFail', true)) {
+            throw new Exception('Intentional failure so the job lands in failed_jobs.');
+        }
+
+        parent::handle();
+    }
+}


### PR DESCRIPTION
Fixes #637

`php artisan queue:retry {uuid}` failed for `TenantAware` jobs with `CurrentTenantCouldNotBeDeterminedInTenantAwareJob` ("No `tenantId` was set in the payload").

`JobRetryRequested` fires inside the `queue:retry` Artisan command, where Laravel has not yet hydrated the stored `illuminate:log:context` onto the `Context` facade. `findTenant()` only read from `Context::get()`, which is empty in that fresh process, so the tenant could not be determined.

## Changes

- `findTenant()` now resolves the tenant id through a new `resolveTenantId()`.
- For `JobRetryRequested`, the tenant id is read straight from the serialized context stored in the job payload (`illuminate:log:context` → `data` → context key), per job. This is authoritative for retries and avoids stale context leaking across jobs during a single `queue:retry all` run.
- `JobProcessing` keeps reading from `Context::get()`, which the worker hydrates before the event fires.
- Added feature tests covering a single retried job and retries spanning multiple tenants.