### PR TITLE
Support legacy queue payloads in tenant-awareness detection

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -50,6 +50,15 @@ class MakeQueueTenantAwareAction
     {
         $payload = $this->getEventPayload($event);
 
+        /**
+         * Legacy string-job payloads ({"job":"Class@method","data":{...}}) - pushed by
+         * something other than Laravel's dispatcher, e.g. AWS EventBridge - have no
+         * serialized command. Resolve the class name straight from the payload instead.
+         */
+        if (! isset($payload['data']['command'])) {
+            return $this->resolveTenantAwarenessForJob($this->jobClassFromLegacyPayload($payload));
+        }
+
         $serializedCommand = $payload['data']['command'];
 
         if (! str_starts_with($serializedCommand, 'O:')) {
@@ -72,7 +81,19 @@ class MakeQueueTenantAwareAction
             $command = unserialize($serializedCommand);
         }
 
-        $job = $this->getJobFromQueueable($command);
+        return $this->resolveTenantAwarenessForJob($this->getJobFromQueueable($command));
+    }
+
+    /**
+     * Determine tenant-awareness from a job's interface declarations and the
+     * configured allow/deny lists, falling back to the package default. Accepts
+     * either a job instance (modern payloads) or a class name (legacy payloads).
+     */
+    protected function resolveTenantAwarenessForJob(object|string|null $job): bool
+    {
+        if ($job === null) {
+            return config('multitenancy.queues_are_tenant_aware_by_default') === true;
+        }
 
         $reflection = new ReflectionClass($job);
 
@@ -93,6 +114,23 @@ class MakeQueueTenantAwareAction
         }
 
         return config('multitenancy.queues_are_tenant_aware_by_default') === true;
+    }
+
+    /**
+     * Resolve the job class name from a legacy string-job payload's `job` key
+     * (`Fully\Qualified\ClassName@method`), or null when it cannot be resolved.
+     */
+    protected function jobClassFromLegacyPayload(array $payload): ?string
+    {
+        $jobName = $payload['job'] ?? null;
+
+        if (! is_string($jobName)) {
+            return null;
+        }
+
+        $class = explode('@', $jobName)[0];
+
+        return class_exists($class) ? $class : null;
     }
 
     protected function getJobFromQueueable(object $queueable)

--- a/tests/Feature/TenantAwareJobs/LegacyQueuePayloadTest.php
+++ b/tests/Feature/TenantAwareJobs/LegacyQueuePayloadTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use Illuminate\Contracts\Queue\Job as QueueJobContract;
+use Illuminate\Queue\Events\JobProcessing;
+use Spatie\Multitenancy\Actions\MakeQueueTenantAwareAction;
+use Spatie\Multitenancy\Models\Tenant;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\NotTenantAwareTestJob;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TenantAwareTestJob;
+use Spatie\Multitenancy\Tests\Feature\TenantAwareJobs\TestClasses\TestJob;
+use Spatie\Valuestore\Valuestore;
+
+beforeEach(function () {
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', false);
+
+    $this->tenant = Tenant::factory()->create();
+});
+
+/*
+ * Legacy string-job payloads ({"job":"Class@method","data":{...}}) are produced when
+ * messages are pushed to the queue by something other than Laravel's dispatcher
+ * (e.g. AWS EventBridge input transformers). They carry no serialized `data.command`,
+ * which used to make isTenantAware() throw "Undefined array key 'command'".
+ */
+function isTenantAwareForPayload(array $payload): bool
+{
+    $job = Mockery::mock(QueueJobContract::class);
+    $job->allows('payload')->andReturn($payload);
+
+    $action = new class () extends MakeQueueTenantAwareAction {
+        public function determine(JobProcessing $event): bool
+        {
+            return $this->isTenantAware($event);
+        }
+    };
+
+    return $action->determine(new JobProcessing('database', $job));
+}
+
+function legacyPayload(string $jobName): array
+{
+    return ['job' => $jobName, 'data' => []];
+}
+
+it('treats a legacy payload as not tenant aware when the job implements NotTenantAware', function () {
+    $isTenantAware = isTenantAwareForPayload(legacyPayload(NotTenantAwareTestJob::class . '@handle'));
+
+    expect($isTenantAware)->toBeFalse();
+});
+
+it('treats a legacy payload as tenant aware when the job implements TenantAware', function () {
+    $isTenantAware = isTenantAwareForPayload(legacyPayload(TenantAwareTestJob::class . '@handle'));
+
+    expect($isTenantAware)->toBeTrue();
+});
+
+it('treats a legacy payload as tenant aware when the job is in the tenant_aware_jobs config', function () {
+    config()->set('multitenancy.tenant_aware_jobs', [TestJob::class]);
+
+    $isTenantAware = isTenantAwareForPayload(legacyPayload(TestJob::class . '@handle'));
+
+    expect($isTenantAware)->toBeTrue();
+});
+
+it('treats a legacy payload as not tenant aware when the job is in the not_tenant_aware_jobs config', function () {
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+    config()->set('multitenancy.not_tenant_aware_jobs', [TestJob::class]);
+
+    $isTenantAware = isTenantAwareForPayload(legacyPayload(TestJob::class . '@handle'));
+
+    expect($isTenantAware)->toBeFalse();
+});
+
+it('falls back to the default (true) when the legacy job class cannot be resolved', function () {
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+
+    $isTenantAware = isTenantAwareForPayload(legacyPayload('App\\Jobs\\SomeMissingClass@handle'));
+
+    expect($isTenantAware)->toBeTrue();
+});
+
+it('falls back to the default (false) when the legacy job class cannot be resolved', function () {
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', false);
+
+    $isTenantAware = isTenantAwareForPayload(legacyPayload('App\\Jobs\\SomeMissingClass@handle'));
+
+    expect($isTenantAware)->toBeFalse();
+});
+
+it('falls back to the default when the legacy payload has no job key', function () {
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+
+    $isTenantAware = isTenantAwareForPayload(['data' => []]);
+
+    expect($isTenantAware)->toBeTrue();
+});
+
+it('leaves modern data.command payloads unchanged', function () {
+    // With the default on, a modern job is only classified from its serialized command in
+    // data.command. Its top-level `job` is Illuminate\Queue\CallQueuedHandler@call - never
+    // the job class - so if the legacy branch hijacked modern payloads this would flip to true.
+    config()->set('multitenancy.queues_are_tenant_aware_by_default', true);
+
+    $valuestore = Valuestore::make(tempFile('tenantAware.json'))->flush();
+
+    $isTenantAware = isTenantAwareForPayload([
+        'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+        'data' => [
+            'commandName' => NotTenantAwareTestJob::class,
+            'command' => serialize(new NotTenantAwareTestJob($valuestore)),
+        ],
+    ]);
+
+    expect($isTenantAware)->toBeFalse();
+});
+
+it('no longer throws when the real event path processes a legacy payload', function () {
+    // Regression for the original crash: firing JobProcessing for a legacy NotTenantAware
+    // payload used to throw "Undefined array key 'command'" before the interface was read.
+    $this->tenant->makeCurrent();
+
+    $job = Mockery::mock(QueueJobContract::class);
+    $job->allows('payload')->andReturn(legacyPayload(NotTenantAwareTestJob::class . '@handle'));
+    $job->allows('delete');
+
+    event(new JobProcessing('database', $job));
+
+    expect(Tenant::current())->toBeNull();
+});


### PR DESCRIPTION
### Problem

`MakeQueueTenantAwareAction::isTenantAware()` reads `$payload['data']['command']` unconditionally. Modern Laravel payloads always carry the serialized job there, but **legacy string-job payloads have no `data.command`**:

```json
{ "job": "App\\Jobs\\SyncInventory@handle", "data": { "sku": "ABC-123" } }
```

This shape is produced whenever messages reach the queue from something other than Laravel's dispatcher — e.g. **AWS EventBridge input transformers** pushing to SQS, or any raw `Queue::pushRaw`-style producer. Laravel's worker still runs them via `$instance->handle($job, $data)`, and fires `JobProcessing` as usual.

Because `data.command` is absent, the action throws **`Undefined array key "command"`** before it ever reaches the interface checks. So a legacy-format job that implements `NotTenantAware` (or `TenantAware`) has its declaration silently ignored, and the worker errors instead of processing the job.

### Fix

When `data.command` is absent, resolve the job class straight from `payload['job']` (stripping the `@method` suffix) and run the **existing** interface / config-list / default checks against that class name (`ReflectionClass` accepts a class-string). The decision logic is extracted into a shared helper so both paths behave identically.

- Honors all the same config knobs: `tenant_aware_interface`, `not_tenant_aware_interface`, `tenant_aware_jobs`, `not_tenant_aware_jobs`, `queues_are_tenant_aware_by_default`.
- If the class can't be resolved (missing `job` key, or class doesn't exist) it falls back to `queues_are_tenant_aware_by_default` — it never throws.
- The legacy path has nothing to unserialize and no encrypted command, so no decryption/unserialization is attempted there.

### Zero impact on modern payloads

Modern `Queueable` jobs always carry `data.command` (the real job is serialized inside it; the top-level `job` is `Illuminate\Queue\CallQueuedHandler@call`, not the job class). The new branch triggers **only** when `data.command` is genuinely absent, so the modern path is unchanged — the added risk surface is limited to payloads that currently crash. A regression test asserts this and fails if the legacy branch is ever allowed to touch a modern payload.

### Tests

New `LegacyQueuePayloadTest` covering: legacy `NotTenantAware` → false; legacy `TenantAware` → true; legacy class in `tenant_aware_jobs` / `not_tenant_aware_jobs` → respective result; unresolvable/missing class → falls back to the default (both `true` and `false`); missing `job` key → default; a modern `data.command` payload behaves exactly as before; and an end-to-end regression firing `JobProcessing` for a legacy payload no longer throws.
