### PR TITLE
Fix tenant id retrival during job retry

### DIFF
--- a/src/Actions/MakeQueueTenantAwareAction.php
+++ b/src/Actions/MakeQueueTenantAwareAction.php
@@ -73,7 +73,7 @@ class MakeQueueTenantAwareAction
              * have global scopes set that require a current tenant to
              * be active. bindOrForgetCurrentTenant wil reset it.
              */
-            if ($tenantId = Context::get($this->currentTenantContextKey())) {
+            if ($tenantId = $this->resolveTenantId($event)) {
                 $tenant = app(IsTenant::class)::find($tenantId);
                 $tenant?->makeCurrent();
             }


### PR DESCRIPTION
If I run `php artisan queue:retry 4bc59fc5-010c-4d46-a9d4-4e0128e9e300` on a job that contains a serialized model, the tenant id is not resolved in the `isTenantAware()` function.

Error stacktrace:
```
[previous exception] [object] (PDOException(code: 3D000): SQLSTATE[3D000]: Invalid catalog name: 1046 No database selected at /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Connection.php:435)
[stacktrace]
#0 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Connection.php(435): PDO->prepare()
#1 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Connection.php(846): Illuminate\\Database\\Connection->{closure:Illuminate\\Database\\Connection::select():426}()
#2 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Connection.php(813): Illuminate\\Database\\Connection->runQueryCallback()
#3 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Connection.php(426): Illuminate\\Database\\Connection->run()
#4 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3573): Illuminate\\Database\\Connection->select()
#5 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php(3557): Illuminate\\Database\\Query\\Builder->runSelect()
#6 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(908): Illuminate\\Database\\Query\\Builder->get()
#7 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(890): Illuminate\\Database\\Eloquent\\Builder->getModels()
#8 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Concerns/BuildsQueries.php(366): Illuminate\\Database\\Eloquent\\Builder->get()
#9 /home/user/projects/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php(782): Illuminate\\Database\\Eloquent\\Builder->first()
#10 /home/user/projects/vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php(112): Illuminate\\Database\\Eloquent\\Builder->firstOrFail()
#11 /home/user/projects/vendor/laravel/framework/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php(63): Illuminate\\Notifications\\Notification->restoreModel()
#12 /home/user/projects/vendor/laravel/framework/src/Illuminate/Queue/SerializesModels.php(98): Illuminate\\Notifications\\Notification->getRestoredPropertyValue()
#13 [internal function]: Illuminate\\Notifications\\Notification->__unserialize()
#14 /home/user/projects/vendor/spatie/laravel-multitenancy/src/Actions/MakeQueueTenantAwareAction.php(81): unserialize()
#15 /home/user/projects/vendor/spatie/laravel-multitenancy/src/Actions/MakeQueueTenantAwareAction.php(216): Spatie\\Multitenancy\\Actions\\MakeQueueTenantAwareAction->isTenantAware()
#16 /home/user/projects/vendor/spatie/laravel-multitenancy/src/Actions/MakeQueueTenantAwareAction.php(43): Spatie\\Multitenancy\\Actions\\MakeQueueTenantAwareAction->bindOrForgetCurrentTenant()
#17 /home/user/projects/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(493): Spatie\\Multitenancy\\Actions\\MakeQueueTenantAwareAction->{closure:Spatie\\Multitenancy\\Actions\\MakeQueueTenantAwareAction::listenForJobsRetryRequested():42}()
#18 /home/user/projects/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(323): 
```